### PR TITLE
Add convenience method to PassThroughManager

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -411,3 +411,17 @@ define a custom manager that inherits from ``PassThroughManager``::
    fly, which broke pickling of those querysets. For this reason,
    ``PassThroughManager`` is recommended instead.
 
+If you would like your custom ``QuerySet`` methods available through related
+managers, use the convenience ``PassThroughManager.for_queryset_class``. For
+example::
+
+    class Post(models.Model):
+        user = models.ForeignKey(User)
+        published = models.DateTimeField()
+
+        objects = PassThroughManager.for_queryset_class(PostQuerySet)()
+
+Now you will be able to make queries like::
+
+    >>> u = User.objects.all()[0]
+    >>> a.post_set.published()

--- a/model_utils/managers.py
+++ b/model_utils/managers.py
@@ -126,6 +126,17 @@ class PassThroughManager(models.Manager):
             return self._queryset_cls(**kargs)
         return super(PassThroughManager, self).get_query_set()
 
+    @classmethod
+    def for_queryset_class(cls, queryset_cls):
+        class _PassThroughManager(cls):
+            def get_query_set(self):
+                kwargs = {}
+                if hasattr(self, "_db"):
+                    kwargs["using"] = self._db
+                return queryset_cls(self.model, **kwargs)
+
+        return _PassThroughManager
+
 
 def manager_from(*mixins, **kwds):
     """

--- a/model_utils/tests/models.py
+++ b/model_utils/tests/models.py
@@ -225,3 +225,27 @@ class Dude(models.Model):
 
     objects = PassThroughManager(DudeQuerySet)
     abiders = AbidingManager()
+
+
+class Car(models.Model):
+    name = models.CharField(max_length=20)
+    owner = models.ForeignKey(Dude, related_name='cars_owned')
+
+    objects = PassThroughManager(DudeQuerySet)
+
+
+class SpotQuerySet(models.query.QuerySet):
+    def closed(self):
+        return self.filter(closed=True)
+
+    def secured(self):
+        return self.filter(secure=True)
+
+
+class Spot(models.Model):
+    name = models.CharField(max_length=20)
+    secure = models.BooleanField(default=True)
+    closed = models.BooleanField(default=False)
+    owner = models.ForeignKey(Dude, related_name='spots_owned')
+
+    objects = PassThroughManager.for_queryset_class(SpotQuerySet)()


### PR DESCRIPTION
Hi Carl. First off, thanks a bunch for this package. I use it in all my Django work.

When I migrated over to `PassThroughManager` from `manager_from`, I lost the ability to access my `QuerySet` methods from related managers. I couldn't do something like:

```
>>> user = User.objects.filter(...)[0]
>>> user.post_set.published()
AttributeError ... 
```

When the related manager is instantiated, it doesn't pass the `QuerySet` class and its methods aren't available.

The solution is very simple. Subclass `PassThroughManager` and always return the custom `QuerySet` class from `get_query_set`. To provide a consistent API, I end up having to do this any time I use `PassThroughManager`, which isn't terrible but is a bit inconvenient.

In my patch, I added a class method `for_queryset_class` to `PassThroughManager` that does the above. I also added a test to check for issues with pickling (I haven't investigated the root cause of `manager_from`'s fate) and it seems okay.

I don't know if the API is the best, but it at least demonstrates the convenience of such a concept.
