### PR TITLE
Django 1.4 Time Zone Support

### DIFF
--- a/model_utils/fields.py
+++ b/model_utils/fields.py
@@ -5,6 +5,13 @@ from django.conf import settings
 
 from model_utils import Choices
 
+
+try:
+    from django.utils.timezone import now as now
+except ImportError:
+    now = datetime.now
+
+
 class AutoCreatedField(models.DateTimeField):
     """
     A DateTimeField that automatically populates itself at
@@ -15,7 +22,7 @@ class AutoCreatedField(models.DateTimeField):
     """
     def __init__(self, *args, **kwargs):
         kwargs.setdefault('editable', False)
-        kwargs.setdefault('default', datetime.now)
+        kwargs.setdefault('default', now)
         super(AutoCreatedField, self).__init__(*args, **kwargs)
 
 
@@ -27,7 +34,7 @@ class AutoLastModifiedField(AutoCreatedField):
 
     """
     def pre_save(self, model_instance, add):
-        value = datetime.now()
+        value = now()
         setattr(model_instance, self.attname, value)
         return value
 
@@ -67,7 +74,7 @@ class MonitorField(models.DateTimeField):
 
     """
     def __init__(self, *args, **kwargs):
-        kwargs.setdefault('default', datetime.now)
+        kwargs.setdefault('default', now)
         monitor = kwargs.pop('monitor', None)
         if not monitor:
             raise TypeError(
@@ -88,7 +95,7 @@ class MonitorField(models.DateTimeField):
                 self.get_monitored_value(instance))
 
     def pre_save(self, model_instance, add):
-        value = datetime.now()
+        value = now()
         previous = getattr(model_instance, self.monitor_attname, None)
         current = self.get_monitored_value(model_instance)
         if previous != current:

--- a/model_utils/models.py
+++ b/model_utils/models.py
@@ -13,6 +13,12 @@ from model_utils.managers import manager_from, InheritanceCastMixin, \
 from model_utils.fields import AutoCreatedField, AutoLastModifiedField, \
     StatusField, MonitorField
 
+try:
+    from django.utils.timezone import now as now
+except ImportError:
+    now = datetime.now
+
+
 class InheritanceCastModel(models.Model):
     """
     An abstract base class that provides a ``real_type`` FK to ContentType.
@@ -119,13 +125,13 @@ def add_timeframed_query_manager(sender, **kwargs):
         sender._meta.get_field('timeframed')
         raise ImproperlyConfigured("Model '%s' has a field named "
                                    "'timeframed' which conflicts with "
-                                   "the TimeFramedModel manager." 
+                                   "the TimeFramedModel manager."
                                    % sender.__name__)
     except FieldDoesNotExist:
         pass
     sender.add_to_class('timeframed', QueryManager(
-        (models.Q(start__lte=datetime.now) | models.Q(start__isnull=True)) &
-        (models.Q(end__gte=datetime.now) | models.Q(end__isnull=True))
+        (models.Q(start__lte=now) | models.Q(start__isnull=True)) &
+        (models.Q(end__gte=now) | models.Q(end__isnull=True))
     ))
 
 


### PR DESCRIPTION
I've updated these to use a now() function. This attempts to first import the now() function from `django.utils.timezones` and if ImportError occurs it will use datetime.now().
