### PR TITLE
Allow `manager_from` to return instance or class

### DIFF
--- a/model_utils/managers.py
+++ b/model_utils/managers.py
@@ -177,6 +177,7 @@ def manager_from(*mixins, **kwds):
         stacklevel=2)
     # collect separately the mixin classes and methods
     bases = [kwds.get('queryset_cls', QuerySet)]
+    as_class = kwds.pop('as_class', False)
     methods = {}
     for mixin in mixins:
         if isinstance(mixin, (ClassType, type)):
@@ -205,4 +206,7 @@ def manager_from(*mixins, **kwds):
         qs.__class__ = new_queryset_cls
         return qs
     new_manager_cls.get_query_set = get_query_set
-    return new_manager_cls()
+    if as_class:
+        return new_manager_cls
+    else:
+        return new_manager_cls()


### PR DESCRIPTION
This allows the `manager_from` method to return a manager class.  This is useful for creating manager base classes that can be further extended.

For example:

```
AbstractManagerClass = manager_from(SomeMixin, AnotherMixin, as_class=True)

class NewManager(AbstractManagerClass):
    def confirmed(self):
        return self.filter(status='confirmed')
```
