### PR TITLE
Extra deny methods for PassThroughManager

### DIFF
--- a/model_utils/managers.py
+++ b/model_utils/managers.py
@@ -118,7 +118,8 @@ class PassThroughManager(models.Manager):
 
     """
     # pickling causes recursion errors
-    _deny_methods = ['__getstate__', '__setstate__', '_db']
+    _deny_methods = ['__getstate__', '__setstate__', '__getinitargs__',
+                     '__getnewargs__', '__copy__', '__deepcopy__', '_db']
 
     def __init__(self, queryset_cls=None):
         self._queryset_cls = queryset_cls


### PR DESCRIPTION
Hi!

I got very annoying bug when I copy queryset of model with PassThroughManager. I get extra queries because of **deepcopy** method. Also I got "RuntimeError: dictionary changed size during iteration" because of **getnewargs** method.

I've added extra deny methods to PassThroughManager.
