### PR TITLE
Fix import of managers.py w/ Python 3

### DIFF
--- a/model_utils/managers.py
+++ b/model_utils/managers.py
@@ -1,4 +1,8 @@
-from types import ClassType
+try:
+    from types import ClassType
+except ImportError:
+    # Python 3
+    ClassType = type
 import warnings
 
 from django.contrib.contenttypes.models import ContentType


### PR DESCRIPTION
I tried to port the rest of django-model-utils to Python 3/Django 1.5 but I had some weird test failures that I can't really debug because I'm not really involved with this project.
