### PR TITLE
Add Travis CI config file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,28 @@
+language: python
+
+python:
+  - "2.5"
+  - "2.6"
+  - "2.7"
+
+env:
+  - DJANGO=Django==1.2.7 SOUTH=1
+  - DJANGO=Django==1.3.7 SOUTH=1
+  - DJANGO=Django==1.4.5 SOUTH=1
+  - DJANGO=Django==1.4.5 SOUTH=1
+  - DJANGO=Django==1.5 SOUTH=1
+  - DJANGO=https://github.com/django/django/tarball/master SOUTH=1
+  - DJANGO=Django==1.4.5 SOUTH=0
+
+install:
+  - pip install $DJANGO --use-mirrors
+  - sh -c "if [ '$SOUTH' = '1' ]; then pip install South==0.7.6; fi"
+
+script: python runtests.py
+
+matrix:
+  exclude:
+    - python: "2.5"
+      env: DJANGO=Django==1.5 SOUTH=1
+    - python: "2.5"
+      env: DJANGO=https://github.com/django/django/tarball/master SOUTH=1


### PR DESCRIPTION
I've already confirmed that this file works on Travis CI by running it on my local repository: https://travis-ci.org/treyhunner/django-model-utils/builds/5559574

I also tried adding Python 3.3 tests with Django 1.5 in a separate branch but it is currently failing with Python 3 ([as seen here](https://travis-ci.org/treyhunner/django-model-utils/builds/5559615)).  I also wasn't sure what the lowest supported Django version should be, but the tests seem to pass against Django 1.3.7 at least.

It's relatively easy to remove change this file to check against Django's git master branch as well.

This is the first `.travis.yml` file I've made.  It was easier than I expected.
