### PR TITLE
Implementing __contains__ in Choices

### DIFF
--- a/model_utils/choices.py
+++ b/model_utils/choices.py
@@ -70,6 +70,9 @@ class Choices(object):
         except KeyError:
             raise AttributeError(attname)
 
+    def __contains__(self, attname):
+        return attname in self._choice_dict
+
     def __getitem__(self, index):
         return self._choices[index]
 


### PR DESCRIPTION
Currently '"foo" in choices' returns False even if 'getattr(choices, "foo")' is perfectly valid. Implement a **contains** to make them work consistently
