### PR TITLE
Add PyPI version and download count badges

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,6 +6,10 @@ django-model-utils
    :target: http://travis-ci.org/carljm/django-model-utils
 .. image:: https://coveralls.io/repos/carljm/django-model-utils/badge.png?branch=master
    :target: https://coveralls.io/r/carljm/django-model-utils
+.. image:: https://pypip.in/v/django-model-utils/badge.png
+   :target: https://crate.io/packages/django-model-utils
+.. image:: https://pypip.in/d/django-model-utils/badge.png
+   :target: https://crate.io/packages/django-model-utils
 
 Django model mixins and utilities.
 


### PR DESCRIPTION
Thoughts on adding either of these new badges?

I'm not sure whether downloads should reflect only the latest version or
all downloads (either is possible).  Also not sure whether we should
change the links from crate.io to PyPI.
