### PR TITLE
Add a CONTRIBUTING file

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -11,7 +11,7 @@ Issues are often easier to reproduce/resolve when they have:
 
 - A pull request with a failing test demonstrating the issue
 - A code example that produces the issue consistently
-- A traceback or an guest guest as to where the problem may be occurring
+- A traceback (when applicable)
 
 Pull Requests
 -------------
@@ -43,3 +43,6 @@ First install tox::
 To run tox and generate a coverage report (in ``htmlcov`` directory)::
 
     ./runtests.sh
+
+**Please note**: Before a pull request can be merged, all tests must pass and
+code/branch coverage in tests must be 100%.


### PR DESCRIPTION
I based this off of the CONTRIBUTING.rst file I include in many of my own projects.

This is a very personal document since it sets the tone of the project for contributors.  I've imposed one tone on the document.  I suggest this be edited/rewritten in this pull request until it's appropriate for merging.

I think something resembling that third section is necessary since it's not necessarily intuitive (for newcomers) how the tests should be run at the moment.  I don't have very strong opinions on the other two sections.

django-import-export has a much more detailed CONTRIBUTING file that we could steal some ideas from: https://github.com/bmihelac/django-import-export/blob/master/CONTRIBUTING.md
