### PR TITLE
Save with untracked updated fields

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -19,3 +19,4 @@ Simon Meers <simon@simonmeers.com>
 sayane
 Trey Hunner <trey@treyhunner.com>
 zyegfryed
+Mikhail Silonov <silonov.pro>

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,9 @@ master (unreleased)
 * `Choices` now `__contains__` its Python identifier values. Thanks Keryn
   Knight. (Merge of GH-69).
 
+* Fixed a bug causing ``KeyError`` when saving with the parameter
+  ``update_fields`` in which there are untracked fields.
+
 
 1.4.0 (2013.06.03)
 ------------------

--- a/model_utils/tests/tests.py
+++ b/model_utils/tests/tests.py
@@ -923,6 +923,16 @@ class FieldTrackedModelCustomTests(FieldTrackerTestCase,
         self.instance.save()
         self.assertCurrent(name='new age')
 
+    def test_update_fields(self):
+        # Django 1.4 doesn't have update_fields
+        if django.VERSION >= (1, 5, 0):
+            self.update_instance(name='retro', number=4)
+            self.assertChanged()
+            self.instance.name = 'new age'
+            self.instance.number = 8
+            self.instance.save(update_fields=['name', 'number'])
+            self.assertChanged()
+
 
 class FieldTrackedModelAttributeTests(FieldTrackerTestCase):
 
@@ -976,7 +986,7 @@ class FieldTrackedModelAttributeTests(FieldTrackerTestCase):
 
 
 class FieldTrackedModelMultiTests(FieldTrackerTestCase,
-                                   FieldTrackerCommonTests):
+                                  FieldTrackerCommonTests):
 
     tracked_class = TrackedMultiple
 


### PR DESCRIPTION
Fixed a bug causing `KeyError` when saving with the parameter `update_fields` in which there are untracked fields.
Also in a few places added the generator expression for optimization and `set(...)` for a quick check on the elements entering the tracked fields.
