### PR TITLE
Add code style checks to tox tests

### DIFF
--- a/model_utils/choices.py
+++ b/model_utils/choices.py
@@ -75,7 +75,7 @@ class Choices(object):
 
     def __repr__(self):
         return '%s(%s)' % (self.__class__.__name__,
-                          ', '.join(("%s" % repr(i) for i in self._full)))
+                           ', '.join(("%s" % repr(i) for i in self._full)))
 
     def __contains__(self, item):
         if item in self._choice_dict.values():

--- a/model_utils/models.py
+++ b/model_utils/models.py
@@ -36,6 +36,7 @@ class TimeFramedModel(models.Model):
     class Meta:
         abstract = True
 
+
 class StatusModel(models.Model):
     """
     An abstract base class model with a ``status`` field that
@@ -50,6 +51,7 @@ class StatusModel(models.Model):
 
     class Meta:
         abstract = True
+
 
 def add_status_query_managers(sender, **kwargs):
     """
@@ -68,6 +70,7 @@ def add_status_query_managers(sender, **kwargs):
         except FieldDoesNotExist:
             pass
         sender.add_to_class(value, QueryManager(status=value))
+
 
 def add_timeframed_query_manager(sender, **kwargs):
     """

--- a/model_utils/tests/tests.py
+++ b/model_utils/tests/tests.py
@@ -334,6 +334,7 @@ class IdentifierChoicesTests(ChoicesTests):
     def test_doesnt_contain_python_attr(self):
         self.assertFalse('PUBLISHED' in self.STATUS)
 
+
 class InheritanceManagerTests(TestCase):
     def setUp(self):
         self.child1 = InheritanceManagerTestChild1.objects.create()

--- a/tox.ini
+++ b/tox.ini
@@ -5,11 +5,20 @@ envlist =
     py32-1.5, py32-1.6, py32-trunk,
     py33-1.5, py33-1.6, py33-trunk
 
+[flake8]
+ignore = 
+max-complexity = 12
+max-line-length = 79
+
 [testenv]
 deps =
     South == 0.8.1
     coverage == 3.6
 commands = coverage run -a setup.py test
+
+[testenv:flake8]
+deps = flake8
+commands = flake8 model_utils
 
 [testenv:py26-1.4]
 basepython = python2.6


### PR DESCRIPTION
The code isn't entirely consistent in style at the moment.

Do you think we should add a code style check as a tox test environment so the code style is checked every time tox is run locally?

[pep438](https://github.com/treyhunner/pep438/blob/master/tox.ini) uses flake8 and py3kwarn for Python 3 compliance for example.

Thoughts on this concept?
