### PR TITLE
preserve reverse_related_field caches when casting to a subclass

### DIFF
--- a/model_utils/managers.py
+++ b/model_utils/managers.py
@@ -86,8 +86,8 @@ class InheritanceQuerySet(QuerySet):
         try:
             node = getattr(obj, rel)
             klass_info = get_klass_info(self.model, max_depth=2, only_load={}, requested=self.query.select_related)
-            for rrf, klass_info in klass_info[4]:
-                related_cache = rrf.related.get_cache_name()
+            for reverse_related_field, klass_info in klass_info[4]:
+                related_cache = reverse_related_field.related.get_cache_name()
                 if hasattr(obj, related_cache) and not hasattr(node, related_cache):
                     setattr(node, related_cache, getattr(obj, related_cache))
         except ObjectDoesNotExist:

--- a/model_utils/managers.py
+++ b/model_utils/managers.py
@@ -85,11 +85,12 @@ class InheritanceQuerySet(QuerySet):
         rel, _, s = s.partition(LOOKUP_SEP)
         try:
             node = getattr(obj, rel)
-            klass_info = get_klass_info(self.model, max_depth=2, only_load={}, requested=self.query.select_related)
-            for reverse_related_field, klass_info in klass_info[4]:
-                related_cache = reverse_related_field.related.get_cache_name()
-                if hasattr(obj, related_cache) and not hasattr(node, related_cache):
-                    setattr(node, related_cache, getattr(obj, related_cache))
+            if node is not None:
+                klass_info = get_klass_info(self.model, max_depth=2, only_load={}, requested=self.query.select_related)
+                for rrf, klass_info in klass_info[4]:
+                    related_cache = rrf.related.get_cache_name()
+                    if hasattr(obj, related_cache) and not hasattr(node, related_cache):
+                        setattr(node, related_cache, getattr(obj, related_cache))
         except ObjectDoesNotExist:
             return None
         if s:

--- a/model_utils/managers.py
+++ b/model_utils/managers.py
@@ -2,7 +2,7 @@ from __future__ import unicode_literals
 import django
 from django.db import models
 from django.db.models.fields.related import OneToOneField
-from django.db.models.query import QuerySet
+from django.db.models.query import QuerySet, get_klass_info
 from django.core.exceptions import ObjectDoesNotExist
 
 try:
@@ -85,6 +85,11 @@ class InheritanceQuerySet(QuerySet):
         rel, _, s = s.partition(LOOKUP_SEP)
         try:
             node = getattr(obj, rel)
+            klass_info = get_klass_info(self.model, max_depth=2, only_load={}, requested=self.query.select_related)
+            for rrf, klass_info in klass_info[4]:
+                related_cache = rrf.related.get_cache_name()
+                if hasattr(obj, related_cache) and not hasattr(node, related_cache):
+                    setattr(node, related_cache, getattr(obj, related_cache))
         except ObjectDoesNotExist:
             return None
         if s:


### PR DESCRIPTION
I was going to write a test for this but the tests currently fail up to 4 assertions when I run them without making a change.  Anyway, I'm new at this whole pull thing so be gentle.

The issue is if i define a class with a related class:

```
class Opportunity(models.Model):
    objects=InheritanceManager()
    pass

class Contest(Opportunity):
    pass

class Terms(models.Model):
    opportunity = models.OneToOneField(Opportunity, related_name='contest_terms')
```

Calling:

```
contests = Opportunity.objects.select_related('contest_terms').filter(id=1)
t = contests[0].contest_terms
assert(len(connection.queries)==1)
```

works because it makes one DB hit and can access the contest_terms as it's been cached by select_related()
changing the query in the first line to include select_subclasses:

```
contests = Opportunity.objects.select_related('contest_terms').select_subclasses('contest').filter(id=1)
```

fails because the related object cache is lost after subclassing so it makes the additional hit to the DB to get the terms.

The fix I proposed will copy the object caches from the base class when _get_sub_obj_recurse finds the appropriate subclass.  This will keep the results of select_related() in the returned model instance.
