### PR TITLE
Implementation for selecting subclasses by Model class rather than string.

### DIFF
--- a/docs/managers.rst
+++ b/docs/managers.rst
@@ -51,6 +51,27 @@ be returned as their actual type, you can pass subclass names to
     nearby_places = Place.objects.select_subclasses("restaurant")
     # restaurants will be Restaurant instances, bars will still be Place instances
 
+    nearby_places = Place.objects.select_subclasses("restaurant", "bar")
+    # all Places will be converted to Restaurant and Bar instances.
+
+It is also possible to use the subclasses themselves as arguments to
+``select_subclasses``, leaving it to calculate the relationship for you:
+
+.. code-block:: python
+
+    nearby_places = Place.objects.select_subclasses(Restaurant)
+    # restaurants will be Restaurant instances, bars will still be Place instances
+
+    nearby_places = Place.objects.select_subclasses(Restaurant, Bar)
+    # all Places will be converted to Restaurant and Bar instances.
+
+It is even possible to mix and match the two:
+
+.. code-block:: python
+
+    nearby_places = Place.objects.select_subclasses(Restaurant, "bar")
+    # all Places will be converted to Restaurant and Bar instances.
+
 ``InheritanceManager`` also provides a subclass-fetching alternative to the
 ``get()`` method:
 

--- a/model_utils/tests/models.py
+++ b/model_utils/tests/models.py
@@ -27,6 +27,8 @@ class InheritanceManagerTestParent(models.Model):
     normal_field = models.TextField()
     objects = InheritanceManager()
 
+    def __unicode__(self):
+        return unicode(self.pk)
 
     def __str__(self):
         return "%s(%s)" % (
@@ -39,6 +41,7 @@ class InheritanceManagerTestParent(models.Model):
 class InheritanceManagerTestChild1(InheritanceManagerTestParent):
     non_related_field_using_descriptor_2 = models.FileField(upload_to="test")
     normal_field_2 = models.TextField()
+    objects = InheritanceManager()
 
 
 class InheritanceManagerTestGrandChild1(InheritanceManagerTestChild1):
@@ -52,7 +55,6 @@ class InheritanceManagerTestGrandChild1_2(InheritanceManagerTestChild1):
 class InheritanceManagerTestChild2(InheritanceManagerTestParent):
     non_related_field_using_descriptor_2 = models.FileField(upload_to="test")
     normal_field_2 = models.TextField()
-    pass
 
 
 


### PR DESCRIPTION
This pull request constitutes the changes required to have #44 in as part of the InheritanceManager, without requiring a separate method API (which was what carljm favoured, when briefly floating the idea on IRC). It includes tests that indicate it seems to have equality parity with passing strings (or nothing) to `select_subclasses`. It does not include documentation as of yet.

The API now exposed is:

```
MyModel.objects.all().select_subclasses(MySubModel, AnotherSubModel)
```

The old API should still work:

```
MyModel.objects.all().select_subclasses()
MyModel.objects.all().select_subclasses('mysubmodel', 'anothersubmodel', 'yet__another__model')
```

As should mixing the two:

```
MyModel.objects.all().select_subclasses('mysubmodel', AnotherSubModel)
```

This is possibly not merge-ready, yet (not least because it needs squashing, and documentation), but I'm opening this for discussion on the implementation I've written, and to see if anyone can improve on it, because while it works, it doesn't feel the nicest.

It makes a few changes to the way select_subclasses is even implemented, in an attempt to validate mistakes, and it sorts the subclasses length-first, to guarantee that depth traversal can't be short circuited by a change in the order of `self.subclasses`.

All tests pass on 1.4.8, 1.5.4 and 1.6.0b3
