### PR TITLE
FieldTracker can't be inherited from abstract model

### DIFF
--- a/model_utils/tests/models.py
+++ b/model_utils/tests/models.py
@@ -250,6 +250,17 @@ class Tracked(models.Model):
     tracker = FieldTracker()
 
 
+class AbstractTracked(models.Model):
+    name = models.CharField(max_length=20)
+    number = models.IntegerField()
+    mutable = MutableField()
+
+    tracker = FieldTracker()
+
+    class Meta:
+        abstract = True
+
+
 class TrackedFK(models.Model):
     fk = models.ForeignKey('Tracked')
 
@@ -284,6 +295,10 @@ class TrackedMultiple(models.Model):
 
 
 class InheritedTracked(Tracked):
+    name2 = models.CharField(max_length=20)
+
+
+class InheritedAbstractTracked(AbstractTracked):
     name2 = models.CharField(max_length=20)
 
 

--- a/model_utils/tests/tests.py
+++ b/model_utils/tests/tests.py
@@ -27,7 +27,7 @@ from model_utils.tests.models import (
     TimeFrameManagerAdded, Dude, SplitFieldAbstractParent, Car, Spot,
     ModelTracked, ModelTrackedFK, ModelTrackedNotDefault, ModelTrackedMultiple, InheritedModelTracked,
     Tracked, TrackedFK, TrackedNotDefault, TrackedNonFieldAttr, TrackedMultiple,
-    InheritedTracked, StatusFieldDefaultFilled, StatusFieldDefaultNotFilled)
+    InheritedTracked, InheritedAbstractTracked, StatusFieldDefaultFilled, StatusFieldDefaultNotFilled)
 
 
 class GetExcerptTests(TestCase):
@@ -1302,6 +1302,16 @@ class FieldTrackerForeignKeyTests(FieldTrackerTestCase):
 class InheritedFieldTrackerTests(FieldTrackerTests):
 
     tracked_class = InheritedTracked
+
+    def test_child_fields_not_tracked(self):
+        self.name2 = 'test'
+        self.assertEqual(self.tracker.previous('name2'), None)
+        self.assertRaises(FieldError, self.tracker.has_changed, 'name2')
+
+
+class InheritedAbstractFieldTrackerTests(FieldTrackerTests):
+
+    tracked_class = InheritedAbstractTracked
 
     def test_child_fields_not_tracked(self):
         self.name2 = 'test'


### PR DESCRIPTION
I added a failing test case for inheriting a `FieldTracker` from an abstract model. It looks like the `class_prepared` signal isn't sent for abstract classes. :/
