### PR TITLE
Fixed #25 - 3-tuple choices on a StatusModel should use the python identifier.

### DIFF
--- a/model_utils/models.py
+++ b/model_utils/models.py
@@ -9,7 +9,7 @@ from django.utils.timezone import now
 from model_utils.managers import QueryManager
 from model_utils.fields import AutoCreatedField, AutoLastModifiedField, \
     StatusField, MonitorField
-
+from model_utils.choices import Choices
 
 class TimeStampedModel(models.Model):
     """
@@ -58,7 +58,13 @@ def add_status_query_managers(sender, **kwargs):
     """
     if not issubclass(sender, StatusModel):
         return
-    for value, name in getattr(sender, 'STATUS', ()):
+    status_choices = getattr(sender, 'STATUS', ())
+    # if we're working with Choices rather than a 2-tuple, inspect and replace
+    # the expected data with the identifier_map, which is a dictionary
+    # that maps the python attrs to values.
+    if isinstance(status_choices, Choices):
+        status_choices = tuple(status_choices._identifier_map.items())
+    for value, name in status_choices:
         try:
             sender._meta.get_field(name)
             raise ImproperlyConfigured("StatusModel: Model '%s' has a field "

--- a/model_utils/tests/models.py
+++ b/model_utils/tests/models.py
@@ -126,6 +126,14 @@ class StatusManagerAdded(StatusModel):
     )
 
 
+class StatusManagerPythonIdentifiers(StatusModel):
+    STATUS = Choices(
+        ("active", 'is_active', _("active")),
+        ("deleted", 'was_deleted', _("deleted")),
+        ("on_hold", 'currently_on_hold', _("on hold")),
+    )
+
+
 
 class Post(models.Model):
     published = models.BooleanField()

--- a/model_utils/tests/tests.py
+++ b/model_utils/tests/tests.py
@@ -28,7 +28,8 @@ from model_utils.tests.models import (
     ModelTracked, ModelTrackedFK, ModelTrackedNotDefault, ModelTrackedMultiple, InheritedModelTracked,
     Tracked, TrackedFK, TrackedNotDefault, TrackedNonFieldAttr, TrackedMultiple,
     InheritedTracked, StatusFieldDefaultFilled, StatusFieldDefaultNotFilled,
-    InheritanceManagerTestChild3, StatusFieldChoicesName)
+    InheritanceManagerTestChild3, StatusFieldChoicesName,
+    StatusManagerPythonIdentifiers)
 
 
 class GetExcerptTests(TestCase):
@@ -1136,6 +1137,23 @@ class StatusManagerAddedTests(TestCase):
                     ('deleted', 'deleted'),
                     )
                 active = models.BooleanField()
+
+
+    def test_three_tuples_use_python_identifier_for_manager(self):
+        """
+        If the STATUS is a Choices object using the 3-value form (db,
+        python identifier, human-readable form), make sure the python
+        attribute names are used as the QueryManager instances.
+        """
+        self.assertTrue(isinstance(StatusManagerPythonIdentifiers.is_active, QueryManager))
+        self.assertTrue(isinstance(StatusManagerPythonIdentifiers.was_deleted, QueryManager))
+        self.assertTrue(isinstance(StatusManagerPythonIdentifiers.currently_on_hold, QueryManager))
+        with self.assertRaises(AttributeError):
+            manager = StatusManagerPythonIdentifiers.active
+        with self.assertRaises(AttributeError):
+            manager = StatusManagerPythonIdentifiers.deleted
+        with self.assertRaises(AttributeError):
+            manager = StatusManagerPythonIdentifiers.on_hold
 
 
 


### PR DESCRIPTION
If a 3-tuple Choices variant is used in a StatusModel, rather than use the db representation as the attribute on the Model, use the given python identifier.

Up for discussion:
- I've had to opt for using `isinstance` (or alternatively, `hasattr`) to get the required data out of the Choices instance, as there is no way I can see of treating it like a tuple. It always returns either the display representation or the the db & display representation, depending on what you're doing (iterating, getting via [0], etc). I'm open to suggestions.
- I'm not sure of the backwards compatibility ramifications of essentially pulling a switcheroo on existent code, and what could/should be done about it.
