### PR TITLE
Move TimeStampedModel docs to models.rst

### DIFF
--- a/docs/managers.rst
+++ b/docs/managers.rst
@@ -94,13 +94,6 @@ it's safe to use as your default manager for the model.
 .. _Django bug #16572: https://code.djangoproject.com/ticket/16572
 
 
-TimeStampedModel
-----------------
-
-This abstract base class just provides self-updating ``created`` and
-``modified`` fields on any model that inherits from it.
-
-
 .. _QueryManager:
 
 QueryManager

--- a/docs/models.rst
+++ b/docs/models.rst
@@ -10,6 +10,13 @@ manager that returns only objects for whom the current date-time lies
 within their time range.
 
 
+TimeStampedModel
+----------------
+
+This abstract base class just provides self-updating ``created`` and
+``modified`` fields on any model that inherits from it.
+
+
 StatusModel
 -----------
 


### PR DESCRIPTION
The documentation of TimeStampedModel is mistakenly in managers.rst. This trivial commit moves it to its place.
