### PR TITLE
Implemented #55 - PassThroughManagers can have tab-completion/dir() support

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,12 @@ CHANGES
 master (unreleased)
 -------------------
 
+* ``PassThroughManager`` now has support for seeing exposed methods via
+  ``dir``, allowing `IPython`_ tab completion to be useful. Merge of GH-104,
+  fixes GH-55.
+
+.. _IPython: http://ipython.org/
+
 
 2.0.3 (2014.03.19)
 -------------------

--- a/model_utils/managers.py
+++ b/model_utils/managers.py
@@ -244,6 +244,20 @@ class PassThroughManagerMixin(object):
             return getattr(self.get_query_set(), name)
         return getattr(self.get_queryset(), name)
 
+    def __dir__(self):
+        """
+        Allow introspection via dir() and ipythonesque tab-discovery.
+
+        We do dir(type(self)) because to do dir(self) would be a recursion
+        error.
+        We call dir(self.get_query_set()) because it is possible that the
+        queryset returned by get_query_set() is interesting, even if
+        self._queryset_cls is None.
+        """
+        my_values = frozenset(dir(type(self)))
+        my_values |= frozenset(dir(self.get_query_set()))
+        return list(my_values)
+
     def get_queryset(self):
         try:
             qs = super(PassThroughManagerMixin, self).get_queryset()


### PR DESCRIPTION
While presumably `PassThroughManager` will eventually be subsumed by the `QuerySet`/`Manager` delegation refactor in Django core, this should allow for slightly better usability in current projects (see #55).

PR mostly exists to get a travis run to cover my back. If it passes and no objections get raised after a suitable period, I'll get it merged.
