### PR TITLE
Don't try to access __slots__ during copy()

### DIFF
--- a/model_utils/managers.py
+++ b/model_utils/managers.py
@@ -225,7 +225,8 @@ class PassThroughManagerMixin(object):
 
     # pickling causes recursion errors
     _deny_methods = ['__getstate__', '__setstate__', '__getinitargs__',
-                     '__getnewargs__', '__copy__', '__deepcopy__', '_db']
+                     '__getnewargs__', '__copy__', '__deepcopy__', '_db',
+                     '__slots__']
 
     def __init__(self, queryset_cls=None):
         self._queryset_cls = queryset_cls


### PR DESCRIPTION
When subclassing Django will copy managers from the ancestor class. Copying in turn calls `copy.copy()` which checks whether the object uses `__slots__` or `__dict__`. This could result in the manager calling `self.get_queryset()` before all models get registered with the ORM.
