### PR TITLE
Test reverse manager not returning all objects. Fails on django 1.5.5, fine on 1.6

### DIFF
--- a/model_utils/tests/tests.py
+++ b/model_utils/tests/tests.py
@@ -1235,6 +1235,11 @@ class CreatePassThroughManagerTests(TestCase):
         Spot.objects.create(
             name='The Crib', owner=self.dude, closed=True, secure=True,
             secret=False)
+        duder = Dude.objects.create(name='Duder', abides=False, has_rug=False)
+        Spot.objects.create(
+            name='Another Crib', owner=duder, closed=True, secure=True,
+            secret=False)
+        self.assertEqual(self.dude.spots_owned.all().closed().count(), 1)
         self.assertEqual(self.dude.spots_owned.closed().count(), 1)
 
     def test_related_queryset_pickling(self):


### PR DESCRIPTION
Tweaked the CreatePassThroughManagerTests.test_reverse_manager to test that the correct related objects are returned. Currently fails on django 1.5.5 (One extra incorrect "spot" owned by another owner returned) but passes on django 1.6 (Only spots belonging to owner returned).
