### PR TITLE
Make related query sets work on older django.

### DIFF
--- a/model_utils/managers.py
+++ b/model_utils/managers.py
@@ -240,6 +240,8 @@ class PassThroughManagerMixin(object):
     def __getattr__(self, name):
         if name in self._deny_methods:
             raise AttributeError(name)
+        if django.VERSION < (1, 6, 0):
+            return getattr(self.get_query_set(), name)
         return getattr(self.get_queryset(), name)
 
     def get_queryset(self):

--- a/model_utils/tests/tests.py
+++ b/model_utils/tests/tests.py
@@ -1238,7 +1238,7 @@ class PassThroughManagerTests(TestCase):
 class CreatePassThroughManagerTests(TestCase):
     def setUp(self):
         self.dude = Dude.objects.create(name='El Duderino')
-        self.other_dude = Dude.objects.create(name='Das D\xc3de')
+        self.other_dude = Dude.objects.create(name='Das Dude')
 
     def test_reverse_manager(self):
         Spot.objects.create(
@@ -1249,6 +1249,7 @@ class CreatePassThroughManagerTests(TestCase):
             name='The Crux', owner=self.other_dude, closed=True, secure=True,
             secret=False
         )
+        self.assertEqual(self.dude.spots_owned.closed().all().count(), 1)
         self.assertEqual(self.dude.spots_owned.closed().count(), 1)
 
     def test_related_queryset_pickling(self):


### PR DESCRIPTION
This supersedes https://github.com/carljm/django-model-utils/pull/106

(I couldn't figure out if I could add to that pull request or not).
