### PR TITLE
preserve reverse_related_field caches when casting to a subclass (redux)

### DIFF
--- a/model_utils/managers.py
+++ b/model_utils/managers.py
@@ -2,7 +2,7 @@ from __future__ import unicode_literals
 import django
 from django.db import models
 from django.db.models.fields.related import OneToOneField
-from django.db.models.query import QuerySet
+from django.db.models.query import QuerySet, get_klass_info
 from django.core.exceptions import ObjectDoesNotExist
 
 try:
@@ -148,6 +148,11 @@ class InheritanceQuerySetMixin(object):
         rel, _, s = s.partition(LOOKUP_SEP)
         try:
             node = getattr(obj, rel)
+            klass_info = get_klass_info(self.model, max_depth=2, only_load={}, requested=self.query.select_related)
+            for rrf, klass_info in klass_info[4]:
+                related_cache = rrf.related.get_cache_name()
+                if hasattr(obj, related_cache) and not hasattr(node, related_cache):
+                    setattr(node, related_cache, getattr(obj, related_cache))
         except ObjectDoesNotExist:
             return None
         if s:

--- a/model_utils/managers.py
+++ b/model_utils/managers.py
@@ -148,11 +148,12 @@ class InheritanceQuerySetMixin(object):
         rel, _, s = s.partition(LOOKUP_SEP)
         try:
             node = getattr(obj, rel)
-            klass_info = get_klass_info(self.model, max_depth=2, only_load={}, requested=self.query.select_related)
-            for reverse_related_field, klass_info in klass_info[4]:
-                related_cache = reverse_related_field.related.get_cache_name()
-                if hasattr(obj, related_cache) and not hasattr(node, related_cache):
-                    setattr(node, related_cache, getattr(obj, related_cache))
+            if node is not None:
+                klass_info = get_klass_info(self.model, max_depth=2, only_load={}, requested=self.query.select_related)
+                for rrf, klass_info in klass_info[4]:
+                    related_cache = rrf.related.get_cache_name()
+                    if hasattr(obj, related_cache) and not hasattr(node, related_cache):
+                        setattr(node, related_cache, getattr(obj, related_cache))
         except ObjectDoesNotExist:
             return None
         if s:

--- a/model_utils/managers.py
+++ b/model_utils/managers.py
@@ -149,8 +149,8 @@ class InheritanceQuerySetMixin(object):
         try:
             node = getattr(obj, rel)
             klass_info = get_klass_info(self.model, max_depth=2, only_load={}, requested=self.query.select_related)
-            for rrf, klass_info in klass_info[4]:
-                related_cache = rrf.related.get_cache_name()
+            for reverse_related_field, klass_info in klass_info[4]:
+                related_cache = reverse_related_field.related.get_cache_name()
                 if hasattr(obj, related_cache) and not hasattr(node, related_cache):
                     setattr(node, related_cache, getattr(obj, related_cache))
         except ObjectDoesNotExist:

--- a/model_utils/tests/models.py
+++ b/model_utils/tests/models.py
@@ -68,6 +68,11 @@ class InheritanceManagerTestChild3(InheritanceManagerTestParent):
         parent_link=True)
 
 
+class InheritanceManagerBackwardsRelation(models.Model):
+    relation = models.OneToOneField(
+        InheritanceManagerTestParent, related_name='backwards_relation')
+
+
 class TimeStamp(TimeStampedModel):
     pass
 

--- a/model_utils/tests/tests.py
+++ b/model_utils/tests/tests.py
@@ -28,7 +28,7 @@ from model_utils.tests.models import (
     ModelTracked, ModelTrackedFK, ModelTrackedNotDefault, ModelTrackedMultiple, InheritedModelTracked,
     Tracked, TrackedFK, TrackedNotDefault, TrackedNonFieldAttr, TrackedMultiple,
     InheritedTracked, StatusFieldDefaultFilled, StatusFieldDefaultNotFilled,
-    InheritanceManagerTestChild3, StatusFieldChoicesName, 
+    InheritanceManagerTestChild3, StatusFieldChoicesName,
     InheritanceManagerBackwardsRelation)
 
 
@@ -1056,11 +1056,14 @@ class InheritanceManagerRelatedTests(InheritanceManagerTests):
             # the child1 instance *should* have a relation, the child2
             # should not.
             self.assertEqual(qs[0].backwards_relation, related_obj)
-            with self.assertRaises(
-                InheritanceManagerBackwardsRelation.DoesNotExist):
-                    qs[1].backwards_relation
-
-
+            if django.VERSION >= (1, 5, 0):
+                with self.assertRaises(
+                    InheritanceManagerBackwardsRelation.DoesNotExist):
+                        qs[1].backwards_relation
+            else:
+                # Django 1.4 caches `None` instead of raising `DoesNotExist`
+                # (see https://code.djangoproject.com/ticket/13839)
+                self.assertIsNone(qs[1].backwards_relation)
 
 
 

--- a/model_utils/tests/tests.py
+++ b/model_utils/tests/tests.py
@@ -3,9 +3,9 @@ from __future__ import unicode_literals
 from datetime import datetime, timedelta
 import pickle
 try:
-    from unittest import skipUnless, expectedFailure
+    from unittest import skipUnless
 except ImportError: # Python 2.6
-    from django.utils.unittest import skipUnless, expectedFailure
+    from django.utils.unittest import skipUnless
 
 import django
 from django.db import models
@@ -1031,7 +1031,6 @@ class InheritanceManagerRelatedTests(InheritanceManagerTests):
         self.assertEqual(qs.get(id=self.child1.id).test_count, 1)
 
 
-    @expectedFailure
     def test_select_related_query_count_via_reverse_relation(self):
         """
         When doing select_subclasses and select_related together, and the


### PR DESCRIPTION
Originally PR #78 by @screamndigit
- Rebased against master,
- fixed comments made in 838493a7bd2afdc8edd4fa8e2ba69f23e811daa2,
- cherry-picked the original commits from
  - Sonicbids/master@21d92e7d5e481f478dfd829a45309b14e57af68e
  - Sonicbids/master@7d2fa5953a9bcc39cd7994365cdf688c47391ae8
  - Sonicbids/master@f65ef5893d6f453e5ba82b4eed108fbf7b6f8761
- removed the expectedFailure to verify the fix.
