### PR TITLE
Use a signal handler instead of patching save.

### DIFF
--- a/model_utils/tests/tests.py
+++ b/model_utils/tests/tests.py
@@ -1497,6 +1497,9 @@ class FieldTrackerTests(FieldTrackerTestCase, FieldTrackerCommonTests):
 
         item.number = 2
         self.assertTrue(item.tracker.has_changed('number'))
+    
+    def test_can_pickle_objects(self):
+        pickle.dumps(self.instance)
 
 
 class FieldTrackedModelCustomTests(FieldTrackerTestCase,


### PR DESCRIPTION
References #83.

Instead of patching the save method of a tracked model class, we can use
a signal handler on post_save, which means we can still pickle our model
class.

Note we can't just listen for the signal from the class we have, but
instead listen for all post_save signals. This means we actually install
a new signal handler for each tracked model class, which fires on all
model save occurrences (and returns immediately if this handler doesn't care).

We probably could improve this to have a registry of tracked models, or
something, that allows us to just install one signal handler, and filter
according to membership.
