### PR TITLE
Add ability to filter an InheritanceQuerySet by model.

### DIFF
--- a/model_utils/managers.py
+++ b/model_utils/managers.py
@@ -170,6 +170,14 @@ class InheritanceQuerySetMixin(object):
             levels = 1
         return levels
 
+    def instance_of(self, model):
+        parent_field = model._meta.parents.values()[0].attname
+        query = '"%s"."%s" IS NOT NULL' % (
+            model._meta.db_table, 
+            parent_field
+        )
+        return self.extra(where=[query])
+
 class InheritanceManagerMixin(object):
     use_for_related_fields = True
 
@@ -184,6 +192,8 @@ class InheritanceManagerMixin(object):
     def get_subclass(self, *args, **kwargs):
         return self.get_queryset().get_subclass(*args, **kwargs)
 
+    def instance_of(self, model):
+        return self.get_queryset().instance_of(model)
 
 class InheritanceQuerySet(InheritanceQuerySetMixin, QuerySet):
     pass

--- a/model_utils/managers.py
+++ b/model_utils/managers.py
@@ -170,7 +170,22 @@ class InheritanceQuerySetMixin(object):
             levels = 1
         return levels
 
-    def instance_of(self, model):
+    def instance_of(self, *models):
+        # If we aren't already selecting the subclasess, we need
+        # to in order to get this to work.
+        
+        where_queries = []
+        for model in models:
+            where_queries.append('(' + ' AND '.join([
+                '"%s"."%s" IS NOT NULL' % (
+                    model._meta.db_table,
+                    field.attname
+                ) for field in model._meta.parents.values()
+            ]) + ')')
+        
+        return self.extra(where=[' OR '.join(where_queries)])
+        
+        # We need to get the 
         parent_field = model._meta.parents.values()[0].attname
         query = '"%s"."%s" IS NOT NULL' % (
             model._meta.db_table, 

--- a/model_utils/managers.py
+++ b/model_utils/managers.py
@@ -171,6 +171,9 @@ class InheritanceQuerySetMixin(object):
         return levels
 
     def instance_of(self, *models):
+        """
+        Fetch only objects that are instances of the provided model(s).
+        """
         # If we aren't already selecting the subclasess, we need
         # to in order to get this to work.
         
@@ -190,7 +193,7 @@ class InheritanceQuerySetMixin(object):
                 ) for field in model._meta.parents.values()
             ]) + ')')
         
-        return self.extra(where=[' OR '.join(where_queries)])
+        return self.select_subclasses(*models).extra(where=[' OR '.join(where_queries)])
 
 class InheritanceManagerMixin(object):
     use_for_related_fields = True
@@ -206,8 +209,8 @@ class InheritanceManagerMixin(object):
     def get_subclass(self, *args, **kwargs):
         return self.get_queryset().get_subclass(*args, **kwargs)
 
-    def instance_of(self, model):
-        return self.get_queryset().instance_of(model)
+    def instance_of(self, *models):
+        return self.get_queryset().instance_of(*models)
 
 class InheritanceQuerySet(InheritanceQuerySetMixin, QuerySet):
     pass

--- a/model_utils/managers.py
+++ b/model_utils/managers.py
@@ -174,24 +174,23 @@ class InheritanceQuerySetMixin(object):
         # If we aren't already selecting the subclasess, we need
         # to in order to get this to work.
         
+        # How can we tell if we are not selecting subclasses?
+        
+        # Is it safe to just apply .select_subclasses(*models)?
+        
+        # Due to https://code.djangoproject.com/ticket/16572, we
+        # can't really do this for anything other than children (ie,
+        # no grandchildren+).
         where_queries = []
         for model in models:
             where_queries.append('(' + ' AND '.join([
                 '"%s"."%s" IS NOT NULL' % (
                     model._meta.db_table,
-                    field.attname
+                    field.attname, # Should this be something else?
                 ) for field in model._meta.parents.values()
             ]) + ')')
         
         return self.extra(where=[' OR '.join(where_queries)])
-        
-        # We need to get the 
-        parent_field = model._meta.parents.values()[0].attname
-        query = '"%s"."%s" IS NOT NULL' % (
-            model._meta.db_table, 
-            parent_field
-        )
-        return self.extra(where=[query])
 
 class InheritanceManagerMixin(object):
     use_for_related_fields = True

--- a/model_utils/tests/tests.py
+++ b/model_utils/tests/tests.py
@@ -992,30 +992,51 @@ class InheritanceManagerUsingModelsTests(TestCase):
 
     def test_limit_to_specific_subclass(self):
         child3 = InheritanceManagerTestChild3.objects.create()
-        results = InheritanceManagerTestParent.objects.select_subclasses().instance_of(InheritanceManagerTestChild3)
+        results = InheritanceManagerTestParent.objects.instance_of(InheritanceManagerTestChild3)
         
         self.assertEqual([child3], list(results))
     
+    @skipUnless(django.VERSION >= (1, 6, 0), "test only applies to Django 1.6+")
     def test_limit_to_specific_grandchild_class(self):
         grandchild1 = InheritanceManagerTestGrandChild1.objects.get()
-        results = InheritanceManagerTestParent.objects.select_subclasses().instance_of(InheritanceManagerTestGrandChild1)
+        results = InheritanceManagerTestParent.objects.instance_of(InheritanceManagerTestGrandChild1)
 
         self.assertEqual([grandchild1], list(results))
     
-    def test_limit_to_child_fetches_grandchildren(self):
-        children = InheritanceManagerTestChild1.objects.select_subclasses().all()
+    def test_limit_to_child_fetches_grandchildren_as_child_class(self):
+        # Not sure if this is the desired behaviour...?
+        children = InheritanceManagerTestChild1.objects.all()
         
-        results = InheritanceManagerTestParent.objects.select_subclasses().instance_of(InheritanceManagerTestChild1)
+        results = InheritanceManagerTestParent.objects.instance_of(InheritanceManagerTestChild1)
+        
+        self.assertEqual(set(children), set(results))
+
+    @skipUnless(django.VERSION >= (1, 6, 0), "test only applies to Django 1.6+")
+    def test_can_fetch_limited_class_grandchildren(self):
+        # Not sure if this is the desired behaviour...?
+        children = InheritanceManagerTestChild1.objects.select_subclasses()
+        
+        results = InheritanceManagerTestParent.objects.instance_of(InheritanceManagerTestChild1).select_subclasses()
         
         self.assertEqual(set(children), set(results))
     
     def test_selecting_multiple_instance_classes(self):
         child3 = InheritanceManagerTestChild3.objects.create()
+        children1 = InheritanceManagerTestChild1.objects.all()
+        
+        results = InheritanceManagerTestParent.objects.instance_of(InheritanceManagerTestChild3, InheritanceManagerTestChild1)
+        
+        self.assertEqual(set([child3] + list(children1)), set(results))
+    
+    @skipUnless(django.VERSION >= (1, 6, 0), "test only applies to Django 1.6+")
+    def test_selecting_multiple_instance_classes_including_grandchildren(self):
+        child3 = InheritanceManagerTestChild3.objects.create()
         grandchild1 = InheritanceManagerTestGrandChild1.objects.get()
         
-        results = InheritanceManagerTestParent.objects.select_subclasses().instance_of(InheritanceManagerTestChild3, InheritanceManagerTestGrandChild1)
+        results = InheritanceManagerTestParent.objects.instance_of(InheritanceManagerTestChild3, InheritanceManagerTestGrandChild1).select_subclasses()
         
         self.assertEqual(set([child3, grandchild1]), set(results))
+        
 
 class InheritanceManagerRelatedTests(InheritanceManagerTests):
     def setUp(self):

--- a/model_utils/tests/tests.py
+++ b/model_utils/tests/tests.py
@@ -990,6 +990,13 @@ class InheritanceManagerUsingModelsTests(TestCase):
         )
         self.assertTrue(all(result.foo == (result.id + 1) for result in results))
 
+    def test_limit_to_specific_subclass(self):
+        child3 = InheritanceManagerTestChild3.objects.create()
+        results = InheritanceManagerTestParent.objects.select_subclasses().instance_of(InheritanceManagerTestChild3)
+        
+        self.assertEqual(1, len(results))
+        self.assertEqual([child3], list(results))
+
 
 class InheritanceManagerRelatedTests(InheritanceManagerTests):
     def setUp(self):

--- a/model_utils/tests/tests.py
+++ b/model_utils/tests/tests.py
@@ -1036,7 +1036,14 @@ class InheritanceManagerUsingModelsTests(TestCase):
         results = InheritanceManagerTestParent.objects.instance_of(InheritanceManagerTestChild3, InheritanceManagerTestGrandChild1).select_subclasses()
         
         self.assertEqual(set([child3, grandchild1]), set(results))
+    
+    def test_select_subclasses_interaction_with_instance_of(self):
+        child3 = InheritanceManagerTestChild3.objects.create()
         
+        results = InheritanceManagerTestParent.objects.select_subclasses(InheritanceManagerTestChild1).instance_of(InheritanceManagerTestChild3)
+        
+        self.assertEqual(set([child3]), set(results))
+    
 
 class InheritanceManagerRelatedTests(InheritanceManagerTests):
     def setUp(self):

--- a/model_utils/tests/tests.py
+++ b/model_utils/tests/tests.py
@@ -994,9 +994,28 @@ class InheritanceManagerUsingModelsTests(TestCase):
         child3 = InheritanceManagerTestChild3.objects.create()
         results = InheritanceManagerTestParent.objects.select_subclasses().instance_of(InheritanceManagerTestChild3)
         
-        self.assertEqual(1, len(results))
         self.assertEqual([child3], list(results))
+    
+    def test_limit_to_specific_grandchild_class(self):
+        grandchild1 = InheritanceManagerTestGrandChild1.objects.get()
+        results = InheritanceManagerTestParent.objects.select_subclasses().instance_of(InheritanceManagerTestGrandChild1)
 
+        self.assertEqual([grandchild1], list(results))
+    
+    def test_limit_to_child_fetches_grandchildren(self):
+        children = InheritanceManagerTestChild1.objects.select_subclasses().all()
+        
+        results = InheritanceManagerTestParent.objects.select_subclasses().instance_of(InheritanceManagerTestChild1)
+        
+        self.assertEqual(set(children), set(results))
+    
+    def test_selecting_multiple_instance_classes(self):
+        child3 = InheritanceManagerTestChild3.objects.create()
+        grandchild1 = InheritanceManagerTestGrandChild1.objects.get()
+        
+        results = InheritanceManagerTestParent.objects.select_subclasses().instance_of(InheritanceManagerTestChild3, InheritanceManagerTestGrandChild1)
+        
+        self.assertEqual(set([child3, grandchild1]), set(results))
 
 class InheritanceManagerRelatedTests(InheritanceManagerTests):
     def setUp(self):


### PR DESCRIPTION
This is based upon the feature in django-polymorphic, where you
can do:

```
SuperClass.objects.instance_of(SubClass)
```

This will result in only objects of the subclass being fetched.

Note: this works with any queryset, keeping the filtering and
ordering applied there.

Is this something that would be considered? I'll write up some tests if that is the case.
