### PR TITLE
Add tests for field tracker methods in save method

### DIFF
--- a/model_utils/tests/models.py
+++ b/model_utils/tests/models.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 
 from django.db import models
+from django.dispatch import Signal
 from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _
 
@@ -277,6 +278,20 @@ class Tracked(models.Model):
     mutable = MutableField()
 
     tracker = FieldTracker()
+
+
+tracked_save_method_called = Signal()
+
+
+class TrackedSave(models.Model):
+    name = models.CharField(max_length=20)
+
+    tracker = FieldTracker(fields=['name'])
+
+    def save(self, *args, **kwargs):
+        instance = super(TrackedSave, self).save(*args, **kwargs)
+        tracked_save_method_called.send(self.__class__, instance=self)
+        return instance
 
 
 class TrackedFK(models.Model):


### PR DESCRIPTION
These tests verify that `FieldTracker` methods work as expected inside the `save()` method of a model.

I used a Django signal to inject assertions into a model's `save()` method and I used a context manager to handle the repetitive signal connecting/disconnecting.  Let me know if you think this approach is overkill.

When I cherry-pick 3496fe42916696db36d799facfbf56f9caaa5035 (from #130) onto these changes and run the tests, three of the four tests fail (the .current() function works properly still).
