### PR TITLE
Use codecov instead of coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,4 +40,4 @@ matrix:
     - env: TOXENV=py33-django_trunk
     - env: TOXENV=py34-django_trunk
 
-after_success: codecov
+after_success: codecov --min-coverage=100

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ env:
   - TOXENV=py34-django_trunk
 
 install:
-  - pip install --upgrade pip setuptools tox virtualenv coveralls
+  - pip install --upgrade pip setuptools tox virtualenv codecov
 
 script:
   - tox
@@ -40,4 +40,4 @@ matrix:
     - env: TOXENV=py33-django_trunk
     - env: TOXENV=py34-django_trunk
 
-after_success: coveralls
+after_success: codecov

--- a/README.rst
+++ b/README.rst
@@ -4,8 +4,8 @@ django-model-utils
 
 .. image:: https://secure.travis-ci.org/carljm/django-model-utils.png?branch=master
    :target: http://travis-ci.org/carljm/django-model-utils
-.. image:: https://coveralls.io/repos/carljm/django-model-utils/badge.png?branch=master
-   :target: https://coveralls.io/r/carljm/django-model-utils
+.. image:: https://img.shields.io/codecov/c/github/carljm/django-model-utils/master.svg
+   :target: http://codecov.io/github/carljm/django-model-utils?branch=master
 .. image:: https://img.shields.io/pypi/v/django-model-utils.svg
    :target: https://crate.io/packages/django-model-utils
 


### PR DESCRIPTION
The biggest benefit of codecov is that it supports branch coverage whereas Coveralls does not.

Codecov also [has a browser plugin](https://codecov.io/#features) that overlays code coverage on diffs and files.

I do not have admin access, so I believe integrating this will require @carljm or another repo admin to enable the repository [on codecov](https://codecov.io/github/carljm/django-model-utils).
