### PR TITLE
Add case-insensitive fields

### DIFF
--- a/docs/fields.rst
+++ b/docs/fields.rst
@@ -66,7 +66,7 @@ field changes:
 (A ``MonitorField`` can monitor any type of field for changes, not only a
 ``StatusField``.)
 
-If a list is passed to the ``when`` parameter, the field will only 
+If a list is passed to the ``when`` parameter, the field will only
 update when it matches one of the specified values:
 
 .. code-block:: python
@@ -124,7 +124,7 @@ without having to access ``content`` directly.
 
 Assuming the ``Article`` model above:
 
-.. code-block:: pycon
+.. code-block:: python
 
     >>> a = Article.objects.all()[0]
     >>> a.body.content
@@ -154,3 +154,29 @@ If no marker is found in the content, the first two paragraphs (where
 paragraphs are blocks of text separated by a blank line) are taken to
 be the excerpt. This number can be customized by setting the
 ``SPLIT_DEFAULT_PARAGRAPHS`` setting.
+
+
+CICharField & CIEmailField
+--------------------------
+
+Case-insensitive variants of ``CharField`` and ``EmailField``. When combined
+with a unique constraint, values that only vary in case will be considered
+to be duplicate. e.g.,
+
+.. code-block:: python
+
+    class User(models.Model):
+        email = models.CIEmailField(unique=True)
+
+    >>> User.objects.create(email='joe@example.com')
+    <CIPerson: CIPerson object>
+    >>> User.objects.create(email='JOE@example.com')
+        ...
+    django.db.utils.IntegrityError: UNIQUE constraint failed: tests_ciperson.email
+
+A ``CIText`` field mixin has also been provided that will alter the ``db_type``
+of a model field.
+
+.. note::
+
+    Supported database backends only include ``postgresql`` and ``sqlite3``.

--- a/model_utils/fields.py
+++ b/model_utils/fields.py
@@ -241,3 +241,23 @@ class SplitField(models.TextField):
         name, path, args, kwargs = super(SplitField, self).deconstruct()
         kwargs['no_excerpt_field'] = True
         return name, path, args, kwargs
+
+
+class CIText(object):
+
+    def db_type(self, connection):
+        engine = connection.settings_dict['ENGINE']
+
+        return {
+            'django.db.backends.postgresql_psycopg2': 'citext',
+            'django.db.backends.postgresql': 'citext',
+            'django.db.backends.sqlite3': 'text collate nocase',
+        }.get(engine, super(CIText, self).db_type(connection))
+
+
+class CICharField(CIText, models.CharField):
+    pass
+
+
+class CIEmailField(CIText, models.EmailField):
+    pass

--- a/tests/models.py
+++ b/tests/models.py
@@ -6,7 +6,7 @@ from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _
 
 from model_utils import Choices
-from model_utils.fields import SplitField, MonitorField, StatusField
+from model_utils.fields import SplitField, MonitorField, StatusField, CICharField, CIEmailField
 from model_utils.managers import QueryManager, InheritanceManager
 from model_utils.models import (
     SoftDeletableModel,
@@ -331,3 +331,8 @@ class CustomSoftDelete(SoftDeletableModel):
     is_read = models.BooleanField(default=False)
 
     objects = CustomSoftDeleteManager()
+
+
+class CIPerson(models.Model):
+    name = CICharField(max_length=20)
+    email = CIEmailField(unique=True)

--- a/tests/test_fields/test_citext_field.py
+++ b/tests/test_fields/test_citext_field.py
@@ -1,0 +1,29 @@
+
+from django.db import IntegrityError, transaction
+from django.test import TestCase
+from tests.models import CIPerson
+
+
+class CaseInsensitiveFieldTests(TestCase):
+    def test_charfield(self):
+        CIPerson.objects.create(name='JOE', email='joe@example.com')
+
+        self.assertEqual(CIPerson.objects.filter(name='JOE').count(), 1)
+        self.assertEqual(CIPerson.objects.filter(name='Joe').count(), 1)
+        self.assertEqual(CIPerson.objects.filter(name='joe').count(), 1)
+
+    def test_emailfield(self):
+        CIPerson.objects.create(name='JOE', email='joe@example.com')
+
+        self.assertEqual(CIPerson.objects.filter(email='JOE@example.com').count(), 1)
+        self.assertEqual(CIPerson.objects.filter(email='Joe@example.com').count(), 1)
+        self.assertEqual(CIPerson.objects.filter(email='joe@example.com').count(), 1)
+
+    def test_unique_constraint(self):
+        # email fields are unique
+        CIPerson.objects.create(name='Joe', email='joe@example.com')
+
+        with transaction.atomic(), self.assertRaises(IntegrityError):
+            CIPerson.objects.create(name='Joe', email='JOE@example.com')
+
+        self.assertEqual(CIPerson.objects.filter(email='JOE@example.com').count(), 1)


### PR DESCRIPTION
Adds case-insensitive CharField & EmailField, as well as a `CIText` field mixin. Useful for email fields as they are commonly treated as case-insensitive.

~~This is built off/supersedes/closes #212.~~
