### PR TITLE
Run tests for Django 1.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ env:
   - TOXENV=py27-django19
   - TOXENV=py27-django110
   - TOXENV=py27-django111
-  - TOXENV=py27-django_trunk
   - TOXENV=py33-django18
   - TOXENV=py34-django18
   - TOXENV=py34-django19
@@ -29,7 +28,6 @@ script:
 
 matrix:
   allow_failures:
-    - env: TOXENV=py27-django_trunk
     - env: TOXENV=py34-django_trunk
     - env: TOXENV=py35-django_trunk
     - env: TOXENV=py36-django111

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,16 +6,20 @@ env:
   - TOXENV=py27-django18
   - TOXENV=py27-django19
   - TOXENV=py27-django110
+  - TOXENV=py27-django111
   - TOXENV=py27-django_trunk
   - TOXENV=py33-django18
   - TOXENV=py34-django18
   - TOXENV=py34-django19
   - TOXENV=py34-django110
+  - TOXENV=py34-django111
   - TOXENV=py34-django_trunk
   - TOXENV=py35-django18
   - TOXENV=py35-django19
   - TOXENV=py35-django110
+  - TOXENV=py35-django111
   - TOXENV=py35-django_trunk
+  - TOXENV=py36-django111
 
 install:
   - pip install --upgrade pip setuptools tox virtualenv coveralls
@@ -28,5 +32,6 @@ matrix:
     - env: TOXENV=py27-django_trunk
     - env: TOXENV=py34-django_trunk
     - env: TOXENV=py35-django_trunk
+    - env: TOXENV=py36-django111
 
 after_success: coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,9 +30,15 @@ matrix:
   include:
     - python: "3.6"
       env: TOXENV=py36-django111
+  exclude:
+    - python: "2.7"
+      env: TOXENV=py36-django111
   allow_failures:
     - env: TOXENV=py34-django_trunk
     - env: TOXENV=py35-django_trunk
+    - env: TOXENV=py27-django111
+    - env: TOXENV=py34-django111
+    - env: TOXENV=py35-django111
     - env: TOXENV=py36-django111
 
 after_success: coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,9 @@ script:
   - tox
 
 matrix:
+  include:
+    - python: "3.6"
+      env: TOXENV=py36-django111
   allow_failures:
     - env: TOXENV=py34-django_trunk
     - env: TOXENV=py35-django_trunk

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py27-django{18,19,110,111,_trunk},
+    py27-django{18,19,110,111},
     py33-django{18},
     py34-django{18,19,110,111,_trunk},
     py35-django{18,19,110,111,_trunk},

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,10 @@
 [tox]
 envlist =
-    py27-django{18,19,110,_trunk},
+    py27-django{18,19,110,111,_trunk},
     py33-django{18},
-    py34-django{18,19,110,_trunk},
-    py35-django{18,19,110,_trunk},
+    py34-django{18,19,110,111,_trunk},
+    py35-django{18,19,110,111,_trunk},
+    py36-django111,
 
 [testenv]
 basepython =
@@ -11,12 +12,14 @@ basepython =
     py33: python3.3
     py34: python3.4
     py35: python3.5
+    py36: python3.6
 
 deps =
     coverage == 3.6
     django18: Django>=1.8,<1.9
     django19: Django>=1.9,<1.10
     django110: Django>=1.10,<1.11
+    django111: Django>=1.11a1,<2.0
     django_trunk: https://github.com/django/django/tarball/master
     freezegun == 0.3.8
 


### PR DESCRIPTION
## Problem

The first alpha for Django 1.11 is out, and the feature are now frozen as per [the roadmap](https://code.djangoproject.com/wiki/Version1.11Roadmap). This adds it to the build matrix.
Since Django's master branch has already dropped support for Python 2, we don't need to test Python 2.7 against it anymore.

## Solution

- Added new environments to Toxfile + Travis, including 1.11 + Python 3.6.
- Marked as allowed failures, tests don't pass yet.
- Removed Python 2.7 vs. Django master

## Commandments

- [x] Write PEP8 compliant code.
- [x] Cover it with tests.
- [ ] Update `CHANGES.rst` file to describe the changes, and quote according issue with `GH-<issue_number>`.
- [x] Pay attention to backward compatibility, or if it breaks it, explain why.
- [x] Update documentation (if relevant).
