### PR TITLE
Update InheritanceIterable to inherit from ModelIterable instead of BaseIterable

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -15,6 +15,7 @@ Facundo Gaich <facugaich@gmail.com>
 Felipe Prenholato <philipe.rp@gmail.com>
 Filipe Ximenes <filipeximenes@gmail.com>
 Gregor Müllegger <gregor@muellegger.de>
+Hanley Hansen <hanleyhansen@gmail.com>
 ivirabyan
 James Oakley <jfunk@funktronics.ca>
 Jannis Leidel <jannis@leidel.info>

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,8 @@ CHANGES
 
 master (unreleased)
 -------------------
+* Update InheritanceIterable to inherit from
+  ModelIterable instead of BaseIterable, fixes GH-277.
 
 3.0.0 (2017.04.13)
 ------------------

--- a/model_utils/managers.py
+++ b/model_utils/managers.py
@@ -7,14 +7,14 @@ try:
     from django.db.models.query import BaseIterable, ModelIterable
 except ImportError:
     # Django 1.8 does not have iterable classes
-    BaseIterable = object
+    BaseIterable, ModelIterable = object, object
 from django.core.exceptions import ObjectDoesNotExist
 
 from django.db.models.constants import LOOKUP_SEP
 from django.utils.six import string_types
 
 
-class InheritanceIterable(BaseIterable):
+class InheritanceIterable(ModelIterable):
     def __iter__(self):
         queryset = self.queryset
         iter = ModelIterable(queryset)

--- a/tests/test_inheritance_iterable.py
+++ b/tests/test_inheritance_iterable.py
@@ -1,0 +1,22 @@
+from __future__ import unicode_literals
+
+from unittest import skipIf
+
+import django
+from django.test import TestCase
+from django.db.models import Prefetch
+
+from tests.models import InheritanceManagerTestParent, InheritanceManagerTestChild1
+
+
+class InheritanceIterableTest(TestCase):
+    @skipIf(django.VERSION[:2] == (1, 10), "Django 1.10 expects ModelIterable not a subclass of it")
+    def test_prefetch(self):
+        qs = InheritanceManagerTestChild1.objects.all().prefetch_related(
+            Prefetch(
+                'normal_field',
+                queryset=InheritanceManagerTestParent.objects.all(),
+                to_attr='normal_field_prefetched'
+            )
+        )
+        self.assertEquals(qs.count(), 0)


### PR DESCRIPTION
## Problem

This PR address issue [#277](https://github.com/jazzband/django-model-utils/issues/277)

## Solution

The solution required updating `InheritanceIterable` to to inherit from `ModelIterable` instead of `BaseIterable` to avoid the exception thrown in Django 1.11's `query.py`:

```python
if queryset is not None and not issubclass(queryset._iterable_class, ModelIterable):
    raise ValueError('Prefetch querysets cannot use values().')
```

## Commandments

- [X] Write PEP8 compliant code.
- [X] Cover it with tests.
- [X] Update `CHANGES.rst` file to describe the changes, and quote according issue with `GH-<issue_number>`.
- [X] Pay attention to backward compatibility, or if it breaks it, explain why.
- [ ] Update documentation (if relevant).
