### PR TITLE
Update Docs - utilities.rst based on issue #195

### DIFF
--- a/docs/utilities.rst
+++ b/docs/utilities.rst
@@ -212,6 +212,50 @@ An example using the model specified above:
     {'title': None}
 
 
+Tracking Foreign Key Fields
+---------------------------
+
+It should be noted that a generic FieldTracker tracks Foreign Keys by db_column name, rather than model field name, and would be accessed as follows:
+
+.. code-block:: python
+
+    from django.db import models
+    from model_utils import FieldTracker
+
+    class Parent(models.Model):
+        name = models.CharField(max_length=64)
+
+    class Child(models.Model):
+        name = models.CharField(max_length=64)
+        parent = models.ForeignKey(Parent)
+
+.. code-block:: pycon
+    
+    >>> p = Parent.objects.create(name='P')
+    >>> c = Child.objects.create(name='C', parent=p)
+    >>> c.tracker.has_changed('parent_id')
+    
+    
+To find the db_column names of your model (using the above example):
+
+.. code-block:: pycon
+
+    >>> for field in Child._meta.fields:
+            field.get_attname_column()
+    ('id', 'id')
+    ('name', 'name')
+    ('parent_id', 'parent_id')
+    
+
+The model field name *may* be used when tracking with a specific tracker:
+ 
+.. code-block:: python
+
+    specific_tracker = FieldTracker(fields=['parent'])
+
+But according to issue #195 this is not recommended for accessing Foreign Key Fields.
+
+
 Checking changes using signals
 ------------------------------
 

--- a/docs/utilities.rst
+++ b/docs/utilities.rst
@@ -228,6 +228,7 @@ It should be noted that a generic FieldTracker tracks Foreign Keys by db_column 
     class Child(models.Model):
         name = models.CharField(max_length=64)
         parent = models.ForeignKey(Parent)
+        tracker = FieldTracker()
 
 .. code-block:: pycon
     


### PR DESCRIPTION
Having encountered this issue a couple of times with FieldTrackers, I thought it would be good to go in the docs! Hope this helps.

## Problem

Generic FieldTrackers track ForeignKey Fields by db_column name, but there is no mention of this in the docs.

Issue #195 

## Solution

Updated the docs.

## Commandments

- [ ] Write PEP8 compliant code.
- [ ] Cover it with tests.
- [ ] Update `CHANGES.rst` file to describe the changes, and quote according issue with `GH-<issue_number>`.
- [ ] Pay attention to backward compatibility, or if it breaks it, explain why.
- [x] Update documentation (if relevant).
