### PR TITLE
Update Travis matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,25 +1,5 @@
 language: python
 
-python: 2.7
-
-env:
-  - TOXENV=py27-django18
-  - TOXENV=py27-django19
-  - TOXENV=py27-django110
-  - TOXENV=py27-django111
-  - TOXENV=py33-django18
-  - TOXENV=py34-django18
-  - TOXENV=py34-django19
-  - TOXENV=py34-django110
-  - TOXENV=py34-django111
-  - TOXENV=py35-django18
-  - TOXENV=py35-django19
-  - TOXENV=py35-django110
-  - TOXENV=py35-django111
-  - TOXENV=py35-django_trunk
-  - TOXENV=py36-django111
-  - TOXENV=py36-django_trunk
-
 install:
   - pip install --upgrade pip setuptools tox virtualenv coveralls
 
@@ -27,6 +7,24 @@ script:
   - tox
 
 matrix:
+  include:
+    - { python: 2.7, env: TOXENV=py27-django18 }
+    - { python: 2.7, env: TOXENV=py27-django19 }
+    - { python: 2.7, env: TOXENV=py27-django110 }
+    - { python: 2.7, env: TOXENV=py27-django111 }
+    - { python: 3.3, env: TOXENV=py33-django18 }
+    - { python: 3.4, env: TOXENV=py34-django18 }
+    - { python: 3.4, env: TOXENV=py34-django19 }
+    - { python: 3.4, env: TOXENV=py34-django110 }
+    - { python: 3.4, env: TOXENV=py34-django111 }
+    - { python: 3.5, env: TOXENV=py35-django18 }
+    - { python: 3.5, env: TOXENV=py35-django19 }
+    - { python: 3.5, env: TOXENV=py35-django110 }
+    - { python: 3.5, env: TOXENV=py35-django111 }
+    - { python: 3.5, env: TOXENV=py35-django_trunk }
+    - { python: 3.6, env: TOXENV=py36-django111 }
+    - { python: 3.6, env: TOXENV=py36-django_trunk }
+
   allow_failures:
     - env: TOXENV=py35-django_trunk
     - env: TOXENV=py36-django111


### PR DESCRIPTION
## Problem

Travis doesn't include all versions of python on any specific vm. For example, specifying python 2.7 only results in python 2.7 and 3.4 being installed to the system.

## Solution

Build the CI matrix in the `include` section, specifying pairs of `TOXENV`s/python versions

## Commandments

- [ ] Write PEP8 compliant code.
- [ ] Cover it with tests.
- [ ] Update `CHANGES.rst` file to describe the changes, and quote according issue with `GH-<issue_number>`.
- [ ] Pay attention to backward compatibility, or if it breaks it, explain why.
- [ ] Update documentation (if relevant).
