### PR TITLE
Django 2.0 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,38 +1,59 @@
 language: python
 
-python: 2.7
-
-env:
-  - TOXENV=py27-django18
-  - TOXENV=py27-django19
-  - TOXENV=py27-django110
-  - TOXENV=py27-django111
-  - TOXENV=py33-django18
-  - TOXENV=py34-django18
-  - TOXENV=py34-django19
-  - TOXENV=py34-django110
-  - TOXENV=py34-django111
-  - TOXENV=py34-django200
-  - TOXENV=py35-django18
-  - TOXENV=py35-django19
-  - TOXENV=py35-django110
-  - TOXENV=py35-django111
-  - TOXENV=py35-django200
-  - TOXENV=py35-django_trunk
-  - TOXENV=py36-django111
-  - TOXENV=py36-django200
-  - TOXENV=py36-django_trunk
+matrix:
+  fast_finish: true
+  include:
+    - python: 2.7
+      env: TOXENV=py27-django18
+    - python: 2.7
+      env: TOXENV=py27-django19
+    - python: 2.7
+      env: TOXENV=py27-django110
+    - python: 2.7
+      env: TOXENV=py27-django111
+    - python: 3.4
+      env: TOXENV=py34-django18
+    - python: 3.4
+      env: TOXENV=py34-django19
+    - python: 3.4
+      env: TOXENV=py34-django110
+    - python: 3.4
+      env: TOXENV=py34-django111
+    - python: 3.4
+      env: TOXENV=py34-django200
+    - python: 3.5
+      env: TOXENV=py35-django18
+    - python: 3.5
+      env: TOXENV=py35-django19
+    - python: 3.5
+      env: TOXENV=py35-django110
+    - python: 3.5
+      env: TOXENV=py35-django111
+    - python: 3.5
+      env: TOXENV=py35-django200
+    - python: 3.5
+      env: TOXENV=py35-djangotrunk
+    - python: 3.6
+      env: TOXENV=py36-django111
+    - python: 3.6
+      env: TOXENV=py36-django200
+    - python: 3.6
+      env: TOXENV=py36-djangotrunk
+  allow_failures:
+    - python: 3.5
+      env: TOXENV=py35-djangotrunk
+    - python: 3.6
+      env: TOXENV=py36-django111
+    - python: 3.6
+      env: TOXENV=py36-djangotrunk
 
 install:
   - pip install --upgrade pip setuptools tox virtualenv coveralls
+  - if [[ $TRAVIS_PYTHON_VERSION == '2.7' ]]; then export PYVER=py27; fi
+  - if [[ $TRAVIS_PYTHON_VERSION == '3.4' ]]; then export PYVER=py34; fi
+  - if [[ $TRAVIS_PYTHON_VERSION == '3.5' ]]; then export PYVER=py35; fi
+  - if [[ $TRAVIS_PYTHON_VERSION == '3.6' ]]; then export PYVER=py36; fi
 
-script:
-  - tox
-
-matrix:
-  allow_failures:
-    - env: TOXENV=py35-django_trunk
-    - env: TOXENV=py36-django111
-    - env: TOXENV=py36-django_trunk
+script: COMMAND='coverage run' tox -e$TOXENV
 
 after_success: coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,12 +12,15 @@ env:
   - TOXENV=py34-django19
   - TOXENV=py34-django110
   - TOXENV=py34-django111
+  - TOXENV=py34-django200
   - TOXENV=py35-django18
   - TOXENV=py35-django19
   - TOXENV=py35-django110
   - TOXENV=py35-django111
+  - TOXENV=py35-django200
   - TOXENV=py35-django_trunk
   - TOXENV=py36-django111
+  - TOXENV=py36-django200
   - TOXENV=py36-django_trunk
 
 install:

--- a/model_utils/managers.py
+++ b/model_utils/managers.py
@@ -247,7 +247,6 @@ class InheritanceQuerySet(InheritanceQuerySetMixin, QuerySet):
 
 
 class InheritanceManagerMixin(object):
-    use_for_related_fields = True
     _queryset_class = InheritanceQuerySet
 
     def get_queryset(self):
@@ -265,7 +264,6 @@ class InheritanceManager(InheritanceManagerMixin, models.Manager):
 
 
 class QueryManagerMixin(object):
-    use_for_related_fields = True
 
     def __init__(self, *args, **kwargs):
         if args:

--- a/model_utils/managers.py
+++ b/model_utils/managers.py
@@ -90,13 +90,25 @@ class InheritanceQuerySetMixin(object):
         new_qs.subclasses = subclasses
         return new_qs
 
-    def _clone(self, klass=None, setup=False, **kwargs):
+    def _chain(self, **kwargs):
         for name in ['subclasses', '_annotated']:
             if hasattr(self, name):
                 kwargs[name] = getattr(self, name)
+
+        return super(InheritanceQuerySetMixin, self)._chain(**kwargs)
+
+    def _clone(self, klass=None, setup=False, **kwargs):
+        if django.VERSION >= (2, 0):
+            return super(InheritanceQuerySetMixin, self)._clone()
+
+        for name in ['subclasses', '_annotated']:
+            if hasattr(self, name):
+                kwargs[name] = getattr(self, name)
+
         if django.VERSION < (1, 9):
             kwargs['klass'] = klass
             kwargs['setup'] = setup
+
         return super(InheritanceQuerySetMixin, self)._clone(**kwargs)
 
     def annotate(self, *args, **kwargs):

--- a/tox.ini
+++ b/tox.ini
@@ -1,19 +1,11 @@
 [tox]
 envlist =
     py27-django{18,19,110,111},
-    py33-django{18},
     py34-django{18,19,110,111,200},
-    py35-django{18,19,110,111,200,_trunk},
-    py36-django{111,200,_trunk},
+    py35-django{18,19,110,111,200,trunk},
+    py36-django{111,200,trunk},
 
 [testenv]
-basepython =
-    py27: python2.7
-    py33: python3.3
-    py34: python3.4
-    py35: python3.5
-    py36: python3.6
-
 deps =
     coverage == 3.6
     django18: Django>=1.8,<1.9
@@ -21,7 +13,7 @@ deps =
     django110: Django>=1.10,<1.11
     django111: Django>=1.11,<1.12
     django200: Django>=2.0,<2.1
-    django_trunk: https://github.com/django/django/tarball/master
+    djangotrunk: https://github.com/django/django/tarball/master
     freezegun == 0.3.8
 
 commands = coverage run -a runtests.py

--- a/tox.ini
+++ b/tox.ini
@@ -2,9 +2,9 @@
 envlist =
     py27-django{18,19,110,111},
     py33-django{18},
-    py34-django{18,19,110,111},
-    py35-django{18,19,110,111,_trunk},
-    py36-django{111,_trunk},
+    py34-django{18,19,110,111,200},
+    py35-django{18,19,110,111,200,_trunk},
+    py36-django{111,200,_trunk},
 
 [testenv]
 basepython =
@@ -20,6 +20,7 @@ deps =
     django19: Django>=1.9,<1.10
     django110: Django>=1.10,<1.11
     django111: Django>=1.11,<1.12
+    django200: Django>=2.0,<2.1
     django_trunk: https://github.com/django/django/tarball/master
     freezegun == 0.3.8
 


### PR DESCRIPTION
See https://github.com/jazzband/django-model-utils/issues/297#issue-280210103

This covers a few areas

- Updating tox to test django 2.0
- Upgrading travis for django 2.0
- Use ``_chain`` in django 2.0 query chaining instead of ``_clone``
- Remove ``use_for_related_fields = True`` in favor of the new MRO for managers

Fixes #297