### PR TITLE
Handle deferred fields in FieldTracker.has_changed() and previous()

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -42,3 +42,4 @@ Trey Hunner <trey@treyhunner.com>
 Karl Wan Nan Wo <karl.wnw@gmail.com>
 zyegfryed
 Radosław Jan Ganczarek <radoslaw@ganczarek.in>
+Jack Cushman <jcushman@law.harvard.edu>

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ CHANGES
 master (unreleased)
 -------------------
 
+- Fix `FieldTracker.has_changed()` and `FieldTracker.previous()` to return
+  correct responses for deferred fields.
+
 3.1.1 (2017.12.17)
 ------------------
 

--- a/docs/utilities.rst
+++ b/docs/utilities.rst
@@ -150,6 +150,10 @@ Returns the value of the given field during the last save:
 
 Returns ``None`` when the model instance isn't saved yet.
 
+If a field is `deferred`_, calling ``previous()`` will load the previous value from the database.
+
+.. _deferred: https://docs.djangoproject.com/en/2.0/ref/models/querysets/#defer
+
 
 has_changed
 ~~~~~~~~~~~
@@ -167,6 +171,8 @@ Returns ``True`` if the given field has changed since the last save. The ``has_c
 The ``has_changed`` method relies on ``previous`` to determine whether a
 field's values has changed.
 
+If a field is `deferred`_ and has been assigned locally, calling ``has_changed()``
+will load the previous value from the database to perform the comparison.
 
 changed
 ~~~~~~~

--- a/model_utils/tracker.py
+++ b/model_utils/tracker.py
@@ -67,12 +67,31 @@ class FieldInstanceTracker(object):
     def has_changed(self, field):
         """Returns ``True`` if field has changed from currently saved value"""
         if field in self.fields:
+            # deferred fields haven't changed
+            if field in self.instance._deferred_fields and field not in self.instance.__dict__:
+                return False
             return self.previous(field) != self.get_field_value(field)
         else:
             raise FieldError('field "%s" not tracked' % field)
 
     def previous(self, field):
         """Returns currently saved value of given field"""
+
+        # handle deferred fields that have not yet been loaded from the database
+        if self.instance.pk and field in self.instance._deferred_fields and field not in self.saved_data:
+
+            # if the field has not been assigned locally, simply fetch and un-defer the value
+            if field not in self.instance.__dict__:
+                self.get_field_value(field)
+
+            # if the field has been assigned locally, store the local value, fetch the database value,
+            # store database value to saved_data, and restore the local value
+            else:
+                current_value = self.get_field_value(field)
+                self.instance.refresh_from_db(fields=[field])
+                self.saved_data[field] = deepcopy(self.get_field_value(field))
+                setattr(self.instance, self.field_map[field], current_value)
+
         return self.saved_data.get(field)
 
     def changed(self):


### PR DESCRIPTION
## Problem

Currently `has_changed()` and `previous()` do not return correct values when working with Django deferred fields.

* `previous()` always returns `None`, even if the deferred value in the database is not `None`.

* `has_changed()` always returns `True`, even if the field has not changed. It also has the side-effect of unnecessarily fetching deferred fields from the database.

* This means that calling `tracker.changed()` unnecessarily loads all deferred fields, which can have a meaningful performance impact.

Here is a simplified real-life example that shows why this would be useful to fix:

    for instance in MyModel.objects.defer('giant_text_field'):
        # ...
        if instance.needs_update:
            instance.giant_text_field = download_giant_text_file(instance)
        # ...
        if instance.tracker.changed():
            instance.save()

The goal here is to use `defer()` combined with `tracker.changed()` to avoid fetching and re-saving `giant_text_field` unless necessary, which has a huge performance impact for this kind of code. But because `has_changed()` always returns `True` for deferred fields, this code will fetch and store an unchanged `giant_text_field` for every instance.

## Solution

I updated `FieldTrackerTests.test_with_deferred()` to show the different ways `defer()` can interact with `has_changed()` and `previous()`. I then updated `has_changed()` and `previous()` to handle those cases. The new behavior is that `previous()` returns the correct previous value for a deferred field, instead of `None`, and `has_changed()` correctly returns whether the field has had a different value assigned to it, while avoiding unnecessary database access.

### Backwards compatibility

The new code will not affect anyone who is not using FieldTracker with deferred fields.

The change could impact existing users if they are relying on the old behavior, in particular if they are relying on `previous()` always returning `None` for deferred values. I don't think it would make sense to do that, but maybe it's possible?

I did not attempt to apply these fixed for the old `ModelTracker`.

### Implementation details/coding decisions

There are two cases we have to handle here. The simpler is the read-only case: an object is fetched with `defer()` and then the tracker is consulted, without any local assignments to the deferred field. In that case we can just return False from `has_changed()`, because a deferred field by definition hasn't changed. For `previous()` we can just examine the value of the field and thereby un-defer it.

Things get more complicated if local code writes to the deferred field, as in my `instance.giant_text_field =` example above. If local code has written a value, then `has_changed()` should go ahead with the comparison using `previous()`. To return a correct result, `previous()` then has to actually fetch the old value from the database to find out if the new value is different.

So that leads to two implementation details. First, to test whether local code has written to the deferred field, I'm checking whether the field is in `instance.__dict__`, which is the test used by Django's `get_deferred_fields()` and thus is probably correct.

Second, to fetch the old value from the database after assignment, I'm using Django's `refresh_from_db()` function with a temp variable to shuffle around the values. This is messy, but I think cleaner than doing the fetch ourselves and re-implementing all the cases handled by `refresh_from_db()`.

## Commandments

- [x] Write PEP8 compliant code.
- [x] Cover it with tests.
- [x] Update `CHANGES.rst` file to describe the changes, and quote according issue with `GH-<issue_number>`.
- [x] Pay attention to backward compatibility, or if it breaks it, explain why.
- [x] Update documentation (if relevant).
