### PR TITLE
Fix handling of deferred fields on django 1.10+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ python:
 - 3.6
 install: pip install tox-travis codecov
 # positional args ({posargs}) to pass into tox.ini
-script: tox -- --cov
+script: tox -- --cov --cov-append
 after_success: codecov
 deploy:
   provider: pypi

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -43,3 +43,4 @@ Trey Hunner <trey@treyhunner.com>
 Karl Wan Nan Wo <karl.wnw@gmail.com>
 zyegfryed
 Radosław Jan Ganczarek <radoslaw@ganczarek.in>
+Lucas Wiman <lucas.wiman@gmail.com>

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,7 @@ CHANGES
 
 master (unreleased)
 -------------------
+- Fix handling of deferred attributes on Django 1.10+, fixes GH-278
 
 3.1.2 (2018.05.09)
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,8 +3,12 @@ CHANGES
 
 master (unreleased)
 -------------------
+
+3.1.2 (2018.05.09)
+------------------
 * Update InheritanceIterable to inherit from
   ModelIterable instead of BaseIterable, fixes GH-277.
+
 
 3.1.1 (2017.12.17)
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,15 +4,13 @@ CHANGES
 master (unreleased)
 -------------------
 - Fix handling of deferred attributes on Django 1.10+, fixes GH-278
+- Fix `FieldTracker.has_changed()` and `FieldTracker.previous()` to return
+  correct responses for deferred fields.
 
 3.1.2 (2018.05.09)
 ------------------
 * Update InheritanceIterable to inherit from
   ModelIterable instead of BaseIterable, fixes GH-277.
-
-
-- Fix `FieldTracker.has_changed()` and `FieldTracker.previous()` to return
-  correct responses for deferred fields.
 
 3.1.1 (2017.12.17)
 ------------------

--- a/model_utils/__init__.py
+++ b/model_utils/__init__.py
@@ -1,4 +1,4 @@
 from .choices import Choices
 from .tracker import FieldTracker, ModelTracker
 
-__version__ = '3.1.1'
+__version__ = '3.1.2'

--- a/model_utils/tracker.py
+++ b/model_utils/tracker.py
@@ -187,7 +187,10 @@ class FieldInstanceTracker(object):
                 field_tracker = FileDescriptorTracker(field_obj.field)
                 setattr(self.instance.__class__, field, field_tracker)
             else:
-                field_tracker = DeferredAttributeTracker(field, type(self.instance))
+                if django.VERSION < (2, 1):
+                    field_tracker = DeferredAttributeTracker(field, type(self.instance))
+                else:
+                    field_tracker = DeferredAttributeTracker(field)
                 setattr(self.instance.__class__, field, field_tracker)
 
 

--- a/model_utils/tracker.py
+++ b/model_utils/tracker.py
@@ -63,8 +63,7 @@ class DescriptorWrapper(object):
                 # This will undefer the field
                 getattr(instance, self.field_name)
             finally:
-                if already_setting:
-                    instance.__dict__.pop(recursion_sentinel_attname, None)
+                instance.__dict__.pop(recursion_sentinel_attname, None)
         if hasattr(self.descriptor, '__set__'):
             self.descriptor.__set__(instance, value)
         else:

--- a/model_utils/tracker.py
+++ b/model_utils/tracker.py
@@ -97,35 +97,19 @@ class FieldInstanceTracker(object):
             def _get_field_name(self):
                 return self.field.name
 
-        if django.VERSION >= (1, 8):
-            self.instance._deferred_fields = self.instance.get_deferred_fields()
-            for field in self.instance._deferred_fields:
-                if django.VERSION >= (1, 10):
-                    field_obj = getattr(self.instance.__class__, field)
-                else:
-                    field_obj = self.instance.__class__.__dict__.get(field)
-                if isinstance(field_obj, FileDescriptor):
-                    field_tracker = FileDescriptorTracker(field_obj.field)
-                    setattr(self.instance.__class__, field, field_tracker)
-                else:
-                    field_tracker = DeferredAttributeTracker(
-                        field_obj.field_name, None)
-                    setattr(self.instance.__class__, field, field_tracker)
-        else:
-            for field in self.fields:
+        self.instance._deferred_fields = self.instance.get_deferred_fields()
+        for field in self.instance._deferred_fields:
+            if django.VERSION >= (1, 10):
+                field_obj = getattr(self.instance.__class__, field)
+            else:
                 field_obj = self.instance.__class__.__dict__.get(field)
-                if isinstance(field_obj, DeferredAttribute):
-                    self.instance._deferred_fields.add(field)
-
-                    # Django 1.4
-                    if django.VERSION >= (1, 5):
-                        model = None
-                    else:
-                        model = field_obj.model_ref()
-
-                    field_tracker = DeferredAttributeTracker(
-                        field_obj.field_name, model)
-                    setattr(self.instance.__class__, field, field_tracker)
+            if isinstance(field_obj, FileDescriptor):
+                field_tracker = FileDescriptorTracker(field_obj.field)
+                setattr(self.instance.__class__, field, field_tracker)
+            else:
+                field_tracker = DeferredAttributeTracker(
+                    field_obj.field_name, None)
+                setattr(self.instance.__class__, field, field_tracker)
 
 
 class FieldTracker(object):

--- a/model_utils/tracker.py
+++ b/model_utils/tracker.py
@@ -107,8 +107,7 @@ class FieldInstanceTracker(object):
                 field_tracker = FileDescriptorTracker(field_obj.field)
                 setattr(self.instance.__class__, field, field_tracker)
             else:
-                field_tracker = DeferredAttributeTracker(
-                    field_obj.field_name, None)
+                field_tracker = DeferredAttributeTracker(field, type(self.instance))
                 setattr(self.instance.__class__, field, field_tracker)
 
 

--- a/model_utils/tracker.py
+++ b/model_utils/tracker.py
@@ -71,8 +71,7 @@ class DescriptorWrapper(object):
 
     @staticmethod
     def cls_for_descriptor(descriptor):
-        has_del = hasattr(descriptor, '__delete__')
-        if has_del:
+        if hasattr(descriptor, '__delete__'):
             return FullDescriptorWrapper
         else:
             return DescriptorWrapper

--- a/model_utils/tracker.py
+++ b/model_utils/tracker.py
@@ -186,10 +186,7 @@ class FieldInstanceTracker(object):
                 field_tracker = FileDescriptorTracker(field_obj.field)
                 setattr(self.instance.__class__, field, field_tracker)
             else:
-                if django.VERSION < (2, 1):
-                    field_tracker = DeferredAttributeTracker(field, type(self.instance))
-                else:
-                    field_tracker = DeferredAttributeTracker(field)
+                field_tracker = DeferredAttributeTracker(field, type(self.instance))
                 setattr(self.instance.__class__, field, field_tracker)
 
 

--- a/tests/models.py
+++ b/tests/models.py
@@ -1,5 +1,6 @@
 from __future__ import unicode_literals, absolute_import
 
+import django
 from django.db import models
 from django.db.models.query_utils import DeferredAttribute
 from django.db.models import Manager
@@ -346,7 +347,10 @@ class StringyDescriptor(object):
             return self
         if self.name in obj.get_deferred_fields():
             # This queries the database, and sets the value on the instance.
-            DeferredAttribute(field_name=self.name, model=cls).__get__(obj, cls)
+            if django.VERSION < (2, 1):
+                DeferredAttribute(field_name=self.name, model=cls).__get__(obj, cls)
+            else:
+                DeferredAttribute(field_name=self.name).__get__(obj, cls)
         return str(obj.__dict__[self.name])
 
     def __set__(self, obj, value):

--- a/tests/models.py
+++ b/tests/models.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals, absolute_import
 
 from django.db import models
+from django.db.models.query_utils import DeferredAttribute
 from django.db.models import Manager
 from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _
@@ -331,3 +332,37 @@ class CustomSoftDelete(SoftDeletableModel):
     is_read = models.BooleanField(default=False)
 
     objects = CustomSoftDeleteManager()
+
+
+class StringyDescriptor(object):
+    """
+    Descriptor that returns a string version of the underlying integer value.
+    """
+    def __init__(self, name):
+        self.name = name
+
+    def __get__(self, obj, cls=None):
+        if obj is None:
+            return self
+        if self.name in obj.get_deferred_fields():
+            # This queries the database, and sets the value on the instance.
+            DeferredAttribute(field_name=self.name, model=cls).__get__(obj, cls)
+        return str(obj.__dict__[self.name])
+
+    def __set__(self, obj, value):
+        obj.__dict__[self.name] = int(value)
+
+
+class CustomDescriptorField(models.IntegerField):
+    def contribute_to_class(self, cls, name, **kwargs):
+        super(CustomDescriptorField, self).contribute_to_class(cls, name, **kwargs)
+        setattr(cls, name, StringyDescriptor(name))
+
+
+class ModelWithCustomDescriptor(models.Model):
+    custom_field = CustomDescriptorField()
+    tracked_custom_field = CustomDescriptorField()
+    regular_field = models.IntegerField()
+    tracked_regular_field = models.IntegerField()
+
+    tracker = FieldTracker(fields=['tracked_custom_field', 'tracked_regular_field'])

--- a/tests/models.py
+++ b/tests/models.py
@@ -352,6 +352,9 @@ class StringyDescriptor(object):
     def __set__(self, obj, value):
         obj.__dict__[self.name] = int(value)
 
+    def __delete__(self, obj):
+        del obj.__dict__[self.name]
+
 
 class CustomDescriptorField(models.IntegerField):
     def contribute_to_class(self, cls, name, **kwargs):

--- a/tests/test_fields/test_field_tracker.py
+++ b/tests/test_fields/test_field_tracker.py
@@ -189,6 +189,7 @@ class FieldTrackerTests(FieldTrackerTestCase, FieldTrackerCommonTests):
         # has_changed() returns False for deferred fields, without un-deferring them.
         # Use an if because ModelTracked doesn't support has_changed() in this case.
         if self.tracked_class == Tracked:
+            self.assertFalse(item.tracker.has_changed('number'))
             if django.VERSION >= (1, 10):
                 self.assertTrue('number' in item.get_deferred_fields())
             else:

--- a/tests/test_fields/test_field_tracker.py
+++ b/tests/test_fields/test_field_tracker.py
@@ -189,7 +189,6 @@ class FieldTrackerTests(FieldTrackerTestCase, FieldTrackerCommonTests):
         # has_changed() returns False for deferred fields, without un-deferring them.
         # Use an if because ModelTracked doesn't support has_changed() in this case.
         if self.tracked_class == Tracked:
-            self.assertEqual(item.tracker.previous('number'), None)
             if django.VERSION >= (1, 10):
                 self.assertTrue('number' in item.get_deferred_fields())
             else:
@@ -197,7 +196,10 @@ class FieldTrackerTests(FieldTrackerTestCase, FieldTrackerCommonTests):
 
         # previous() un-defers field and returns value
         self.assertEqual(item.tracker.previous('number'), 1)
-        self.assertTrue('number' not in item._deferred_fields)
+        if django.VERSION >= (1, 10):
+            self.assertNotIn('number', item.get_deferred_fields())
+        else:
+            self.assertNotIn('number', item._deferred_fields)
 
         # examining a deferred field un-defers it
         item = self.tracked_class.objects.only('name').first()
@@ -223,9 +225,6 @@ class FieldTrackerTests(FieldTrackerTestCase, FieldTrackerCommonTests):
 
             item = self.tracked_class.objects.only('name').first()
             item.number = 2
-
-            # _deferred_fields is not updated by assignment
-            self.assertTrue('number' in item._deferred_fields)
 
             # previous() fetches correct value from database after deferred field is assigned
             self.assertEqual(item.tracker.previous('number'), 1)

--- a/tests/test_fields/test_field_tracker.py
+++ b/tests/test_fields/test_field_tracker.py
@@ -7,6 +7,7 @@ from django.core.exceptions import FieldError
 from django.test import TestCase
 
 from model_utils import FieldTracker
+from model_utils.tracker import DescriptorWrapper
 from tests.models import (
     Tracked, TrackedFK, InheritedTrackedFK, TrackedNotDefault, TrackedNonFieldAttr, TrackedMultiple,
     InheritedTracked, TrackedFileField,
@@ -191,6 +192,7 @@ class FieldTrackerTests(FieldTrackerTestCase, FieldTrackerCommonTests):
         if self.tracked_class == Tracked:
             self.assertFalse(item.tracker.has_changed('number'))
             if django.VERSION >= (1, 10):
+                self.assertIsInstance(item.__class__.number, DescriptorWrapper)
                 self.assertTrue('number' in item.get_deferred_fields())
             else:
                 self.assertTrue('number' in item._deferred_fields)

--- a/tests/test_fields/test_field_tracker.py
+++ b/tests/test_fields/test_field_tracker.py
@@ -181,13 +181,22 @@ class FieldTrackerTests(FieldTrackerTestCase, FieldTrackerCommonTests):
         self.instance.number = 1
         self.instance.save()
         item = list(self.tracked_class.objects.only('name').all())[0]
-        self.assertTrue(item._deferred_fields)
+        if django.VERSION >= (1, 10):
+            self.assertTrue(item.get_deferred_fields())
+        else:
+            self.assertTrue(item._deferred_fields)
 
         self.assertEqual(item.tracker.previous('number'), None)
-        self.assertTrue('number' in item._deferred_fields)
+        if django.VERSION >= (1, 10):
+            self.assertTrue('number' in item.get_deferred_fields())
+        else:
+            self.assertTrue('number' in item._deferred_fields)
 
         self.assertEqual(item.number, 1)
-        self.assertTrue('number' not in item._deferred_fields)
+        if django.VERSION >= (1, 10):
+            self.assertTrue('number' not in item.get_deferred_fields())
+        else:
+            self.assertTrue('number' not in item._deferred_fields)
         self.assertEqual(item.tracker.previous('number'), 1)
         self.assertFalse(item.tracker.has_changed('number'))
 

--- a/tests/test_managers/test_inheritance_manager.py
+++ b/tests/test_managers/test_inheritance_manager.py
@@ -115,9 +115,6 @@ class InheritanceManagerTests(TestCase):
                 "inheritancemanagertestchild2").get(pk=self.child1.pk)
             obj.inheritancemanagertestchild1
 
-    def test_version_determining_any_depth(self):
-        self.assertIsNone(self.get_manager().all()._get_maximum_depth())
-
     def test_manually_specifying_parent_fk_including_grandchildren(self):
         """
         given a Model which inherits from another Model, but also declares

--- a/tests/test_models/test_deferred_fields.py
+++ b/tests/test_models/test_deferred_fields.py
@@ -1,5 +1,6 @@
 from __future__ import unicode_literals
 
+import django
 from django.test import TestCase
 
 from tests.models import ModelWithCustomDescriptor
@@ -30,9 +31,15 @@ class CustomDescriptorTests(TestCase):
     def test_deferred(self):
         instance = ModelWithCustomDescriptor.objects.only('id').get(
             pk=self.instance.pk)
-        self.assertIn('custom_field', instance.get_deferred_fields())
+        if django.VERSION >= (1, 10):
+            self.assertIn('custom_field', instance.get_deferred_fields())
+        else:
+            self.assertIn('custom_field', instance._deferred_fields)
         self.assertEqual(instance.custom_field, '1')
-        self.assertNotIn('custom_field', instance.get_deferred_fields())
+        if django.VERSION >= (1, 10):
+            self.assertNotIn('custom_field', instance.get_deferred_fields())
+        else:
+            self.assertNotIn('custom_field', instance._deferred_fields)
         self.assertEqual(instance.regular_field, 1)
         self.assertEqual(instance.tracked_custom_field, '1')
         self.assertEqual(instance.tracked_regular_field, 1)

--- a/tests/test_models/test_deferred_fields.py
+++ b/tests/test_models/test_deferred_fields.py
@@ -1,0 +1,53 @@
+from __future__ import unicode_literals
+
+from django.test import TestCase
+
+from tests.models import ModelWithCustomDescriptor
+
+
+class CustomDescriptorTests(TestCase):
+    def setUp(self):
+        self.instance = ModelWithCustomDescriptor.objects.create(
+            custom_field='1',
+            tracked_custom_field='1',
+            regular_field=1,
+            tracked_regular_field=1,
+        )
+
+    def test_custom_descriptor_works(self):
+        instance = self.instance
+        self.assertEqual(instance.custom_field, '1')
+        self.assertEqual(instance.__dict__['custom_field'], 1)
+        self.assertEqual(instance.regular_field, 1)
+        instance.custom_field = 2
+        self.assertEqual(instance.custom_field, '2')
+        self.assertEqual(instance.__dict__['custom_field'], 2)
+        instance.save()
+        intance = ModelWithCustomDescriptor.objects.get(pk=instance.pk)
+        self.assertEqual(instance.custom_field, '2')
+        self.assertEqual(instance.__dict__['custom_field'], 2)
+
+    def test_deferred(self):
+        instance = ModelWithCustomDescriptor.objects.only('id').get(
+            pk=self.instance.pk)
+        self.assertIn('custom_field', instance.get_deferred_fields())
+        self.assertEqual(instance.custom_field, '1')
+        self.assertNotIn('custom_field', instance.get_deferred_fields())
+        self.assertEqual(instance.regular_field, 1)
+        self.assertEqual(instance.tracked_custom_field, '1')
+        self.assertEqual(instance.tracked_regular_field, 1)
+
+        self.assertFalse(instance.tracker.has_changed('tracked_custom_field'))
+        self.assertFalse(instance.tracker.has_changed('tracked_regular_field'))
+
+        instance.tracked_custom_field = 2
+        instance.tracked_regular_field = 2
+        self.assertTrue(instance.tracker.has_changed('tracked_custom_field'))
+        self.assertTrue(instance.tracker.has_changed('tracked_regular_field'))
+        instance.save()
+
+        instance = ModelWithCustomDescriptor.objects.get(pk=instance.pk)
+        self.assertEqual(instance.custom_field, '1')
+        self.assertEqual(instance.regular_field, 1)
+        self.assertEqual(instance.tracked_custom_field, '2')
+        self.assertEqual(instance.tracked_regular_field, 2)

--- a/tests/test_models/test_deferred_fields.py
+++ b/tests/test_models/test_deferred_fields.py
@@ -58,3 +58,14 @@ class CustomDescriptorTests(TestCase):
         self.assertEqual(instance.regular_field, 1)
         self.assertEqual(instance.tracked_custom_field, '2')
         self.assertEqual(instance.tracked_regular_field, 2)
+
+        instance = ModelWithCustomDescriptor.objects.only('id').get(pk=instance.pk)
+        if django.VERSION >= (1, 10):
+            # This fails on 1.8 and 1.9, which is a bug in the deferred field
+            # implementation on those versions.
+            instance.tracked_custom_field = 3
+            self.assertEqual(instance.tracked_custom_field, '3')
+            self.assertTrue(instance.tracker.has_changed('tracked_custom_field'))
+            del instance.tracked_custom_field
+            self.assertEqual(instance.tracked_custom_field, '2')
+            self.assertFalse(instance.tracker.has_changed('tracked_custom_field'))

--- a/tox.ini
+++ b/tox.ini
@@ -18,6 +18,10 @@ deps =
     pytest-cov
 ignore_outcome =
     djangotrunk: True
+passenv =
+  CI
+  TRAVIS
+  TRAVIS_*
 
 commands =
     pip install -e .


### PR DESCRIPTION
Fixes #278. cc @utapyngo @djstein 

## Problem

Prior to Django 1.10, deferred attributes were handled by constructing a new model class with custom descriptors for the deferred attributes. After 1.10, deferred fields are tracked by whether the attribute is present in the instance `__dict__`.

`FieldTracker` handled tracking on these fields by overwriting the descriptors on the model class. This means that in 1.10+, the instance model class _is_ the model, so `FieldTracker` can introduce changes to the base class whenever deferred fields are used that persist on other queries. #278 This is reproduced in a test case.

## Solution

I updated the `finalize_class` method to _wrap_ field descriptors. This preserves the custom descriptor behavior, and means that deferring fields does not lead to permanent changes in base model classes. This is only done for django versions after 1.10: the previous behavior is preserved for 1.8 and 1.9.

Since the relevant code branches behavior on unsupported versions of Django, I also removed all branching behavior for versions of django listed as unsupported in the CHANGELOG.

## Commandments

- [ ] Write PEP8 compliant code.
- [x] Cover it with tests. _Reproduced in test cases, which fail prior to 54cc1507a79460497d40f6cba779f67a4b5f8041 and pass afterwards._
- [x] Update `CHANGES.rst` file to describe the changes, and quote according issue with `GH-<issue_number>`.
- [x] Pay attention to backward compatibility, or if it breaks it, explain why. _The only backwards incompatible change is that the `tracker._deferred_fields` attribute is not set on django versions >=1.10. Since `_deferred_fields` is a private attribute, I wouldn't consider this a breaking change._
- [x] Update documentation (if relevant). _I don't think it is relevant.

Regarding PEP8, I ran `flake8`, and it generated a number of errors. I think my code didn't introduce new PEP8 violations, but I'm not sure. If you want, I can submit a separate PR fixing all the PEP8 violations, and rebase onto this branch.