### PR TITLE
Fixes a bug with subclasses missing from a cloned qs

### DIFF
--- a/model_utils/managers.py
+++ b/model_utils/managers.py
@@ -99,7 +99,10 @@ class InheritanceQuerySetMixin(object):
 
     def _clone(self, klass=None, setup=False, **kwargs):
         if django.VERSION >= (2, 0):
-            return super(InheritanceQuerySetMixin, self)._clone()
+            qs = super(InheritanceQuerySetMixin, self)._clone()
+            if hasattr(self, 'subclasses'):
+                qs.subclasses = self.subclasses
+            return qs
 
         for name in ['subclasses', '_annotated']:
             if hasattr(self, name):

--- a/tests/test_managers/test_inheritance_manager.py
+++ b/tests/test_managers/test_inheritance_manager.py
@@ -454,3 +454,7 @@ class InheritanceManagerRelatedTests(InheritanceManagerTests):
         qs = InheritanceManagerTestParent.objects.annotate(
             test_count=models.Count('id')).select_subclasses()
         self.assertEqual(qs.get(id=self.child1.id).test_count, 1)
+
+    def test_clone_when_inheritance_queryset_selects_subclasses_should_clone_them_too(self):
+        qs = InheritanceManagerTestParent.objects.select_subclasses()
+        self.assertEqual(qs.subclasses, qs._clone().subclasses)


### PR DESCRIPTION
## Problem

Cloned `InheritanceQuerySet` misses `subclasses` from the original one.

```
In [37]: qs = Contact.objects.select_subclasses()

In [38]: qs
Out[38]: <InheritanceQuerySet [<EmailContact: EMail contact: ***redacted***>]>

In [39]: qs._clone()
Out[39]: <InheritanceQuerySet [<Contact: Contact object (1)>]>
```

## Solution

`_clone` implementation should copy `subclasses` attribute from the original queryset.

## Commandments

- [x] Write PEP8 compliant code.
- [x] Cover it with tests.
- [ ] Update `CHANGES.rst` file to describe the changes, and quote according issue with `GH-<issue_number>`.
- [x] Pay attention to backward compatibility, or if it breaks it, explain why.
- [x] Update documentation (if relevant).
