### PR TITLE
Fix AUTHORS.rst formatting.

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -1,45 +1,46 @@
-ad-m <github.com/ad-m>
-Alejandro Varas <alej0varas@gmail.com>
-Alex Orange <crazycasta@gmail.com>
-Alexey Evseev <myhappydo@gmail.com>
-Andy Freeland <andy@andyfreeland.net>
-Artis Avotins <artis.avotins@gmail.com>
-Bram Boogaard <b.boogaard@auto-interactive.nl>
-Carl Meyer <carl@dirtcircle.com>
-Curtis Maloney <curtis@tinbrain.net>
-Den Lesnov
-Dmytro Kyrychuk <dmytro.kyrychuck@gmail.com>
-Donald Stufft <donald.stufft@gmail.com>
-Douglas Meehan <dmeehan@gmail.com>
-Facundo Gaich <facugaich@gmail.com>
-Felipe Prenholato <philipe.rp@gmail.com>
-Filipe Ximenes <filipeximenes@gmail.com>
-Gregor Müllegger <gregor@muellegger.de>
-Hanley Hansen <hanleyhansen@gmail.com>
-ivirabyan
-James Oakley <jfunk@funktronics.ca>
-Jannis Leidel <jannis@leidel.info>
-Jarek Glowacki <github.com/jarekwg>
-Javier García Sogo <jgsogo@gmail.com>
-Jeff Elmore <jeffelmore.org>
-Keryn Knight <kerynknight.com>
-Matthew Schinckel <matt@schinckel.net>
-Michael van Tellingen <michaelvantellingen@gmail.com>
-Mike Bryant <mike@mikebryant.me.uk>
-Mikhail Silonov <silonov.pro>
-Patryk Zawadzki <patrys@room-303.com>
-Paul McLanahan <paul@mclanahan.net>
-Philipp Steinhardt <steinhardt@myvision.de>
-Rinat Shigapov <rinatshigapov@gmail.com>
-Rodney Folz <rodney@rodneyfolz.com>
-Romain Garrigues <github.com/romgar>
-rsenkbeil <github.com/rsenkbeil>
-Ryan Kaskel <dev@ryankaskel.com>
-Simon Meers <simon@simonmeers.com>
-sayane
-Tony Aldridge <zaragopha@hotmail.com>
-Travis Swicegood <travis@domain51.com>
-Trey Hunner <trey@treyhunner.com>
-Karl Wan Nan Wo <karl.wnw@gmail.com>
-zyegfryed
-Radosław Jan Ganczarek <radoslaw@ganczarek.in>
+| ad-m <github.com/ad-m>
+| Alejandro Varas <alej0varas@gmail.com>
+| Alex Orange <crazycasta@gmail.com>
+| Alexey Evseev <myhappydo@gmail.com>
+| Andy Freeland <andy@andyfreeland.net>
+| Artis Avotins <artis.avotins@gmail.com>
+| Bram Boogaard <b.boogaard@auto-interactive.nl>
+| Carl Meyer <carl@dirtcircle.com>
+| Curtis Maloney <curtis@tinbrain.net>
+| Den Lesnov
+| Dmytro Kyrychuk <dmytro.kyrychuck@gmail.com>
+| Donald Stufft <donald.stufft@gmail.com>
+| Douglas Meehan <dmeehan@gmail.com>
+| Facundo Gaich <facugaich@gmail.com>
+| Felipe Prenholato <philipe.rp@gmail.com>
+| Filipe Ximenes <filipeximenes@gmail.com>
+| Gregor Müllegger <gregor@muellegger.de>
+| Hanley Hansen <hanleyhansen@gmail.com>
+| ivirabyan
+| James Oakley <jfunk@funktronics.ca>
+| Jannis Leidel <jannis@leidel.info>
+| Jarek Glowacki <github.com/jarekwg>
+| Javier García Sogo <jgsogo@gmail.com>
+| Jeff Elmore <jeffelmore.org>
+| Keryn Knight <kerynknight.com>
+| Martey Dodoo <martey+django-model-utils@mobolic.com>
+| Matthew Schinckel <matt@schinckel.net>
+| Michael van Tellingen <michaelvantellingen@gmail.com>
+| Mike Bryant <mike@mikebryant.me.uk>
+| Mikhail Silonov <silonov.pro>
+| Patryk Zawadzki <patrys@room-303.com>
+| Paul McLanahan <paul@mclanahan.net>
+| Philipp Steinhardt <steinhardt@myvision.de>
+| Rinat Shigapov <rinatshigapov@gmail.com>
+| Rodney Folz <rodney@rodneyfolz.com>
+| Romain Garrigues <github.com/romgar>
+| rsenkbeil <github.com/rsenkbeil>
+| Ryan Kaskel <dev@ryankaskel.com>
+| Simon Meers <simon@simonmeers.com>
+| sayane
+| Tony Aldridge <zaragopha@hotmail.com>
+| Travis Swicegood <travis@domain51.com>
+| Trey Hunner <trey@treyhunner.com>
+| Karl Wan Nan Wo <karl.wnw@gmail.com>
+| zyegfryed
+| Radosław Jan Ganczarek <radoslaw@ganczarek.in>


### PR DESCRIPTION
## Problem

The AUTHORS file does not display properly when parsed as ReStructuredText: https://github.com/jazzband/django-model-utils/blob/68bc61e82517cb01fa36c0d007091a8670425913/AUTHORS.rst

## Solution

Add a pipe character at the beginning of each line so that all authors are not concatenated together when ReStructuredText is parsed.
