### PR TITLE
Update supported Django versions in setup docs.

### DIFF
--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -17,7 +17,6 @@ modify your ``INSTALLED_APPS`` setting.
 Dependencies
 ============
 
-``django-model-utils`` supports `Django`_ 1.8 through 1.10 (latest bugfix
-release in each series only) on Python 2.7, 3.3 (Django 1.8 only), 3.4 and 3.5.
+``django-model-utils`` supports `Django`_ 1.8 to 2.0.
 
 .. _Django: http://www.djangoproject.com/


### PR DESCRIPTION
## Problem

While the supported Django versions in the README were updated in #306, the setup documentation is still out of date.

## Solution

Update setup documentation so that it contains the same supported version information as the README.

