### PR TITLE
Throw an error in FieldTracker when using untracked field with .previous

### DIFF
--- a/model_utils/tracker.py
+++ b/model_utils/tracker.py
@@ -66,14 +66,14 @@ class FieldInstanceTracker(object):
 
     def has_changed(self, field):
         """Returns ``True`` if field has changed from currently saved value"""
-        if field in self.fields:
-            return self.previous(field) != self.get_field_value(field)
-        else:
-            raise FieldError('field "%s" not tracked' % field)
+        return self.previous(field) != self.get_field_value(field)
 
     def previous(self, field):
         """Returns currently saved value of given field"""
-        return self.saved_data.get(field)
+        if field in self.fields:
+            return self.saved_data.get(field)
+        else:
+            raise FieldError('field "%s" not tracked' % field)
 
     def changed(self):
         """Returns dict of fields that changed since save (with old values)"""


### PR DESCRIPTION
## Problem

Previously if `previous` was called on a field tracker and the field was not being tracked it would return `None`. Having consistent behavior between `previous` and `has_changed` would seem to make sense, but there may be a reason why this is not so?

## Solution

I've moved the `FieldError` exception into `previous` from `has_changed`; `has_changed` calles `previous` so the exception will still be used from `has_changed`.

## Commandments

- [x] Write PEP8 compliant code.
- [ ] Cover it with tests.
- [ ] Update `CHANGES.rst` file to describe the changes, and quote according issue with `GH-<issue_number>`.
- [ ] Pay attention to backward compatibility, or if it breaks it, explain why.
- [ ] Update documentation (if relevant).

I can add a test for this if you think it's worth merging?