### PR TITLE
Add default manager as all_objects for SoftDeletableModel

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,9 @@ master (unreleased)
 * Update InheritanceIterable to inherit from
   ModelIterable instead of BaseIterable, fixes GH-277.
 
+* Add all_objects Manager for 'SoftDeletableModel' to include soft
+  deleted objects on queries as per issue GH-255
+
 3.1.1 (2017.12.17)
 ------------------
 

--- a/model_utils/models.py
+++ b/model_utils/models.py
@@ -123,6 +123,7 @@ class SoftDeletableModel(models.Model):
         abstract = True
 
     objects = SoftDeletableManager()
+    all_objects = models.Manager()
 
     def delete(self, using=None, soft=True, *args, **kwargs):
         """


### PR DESCRIPTION
## Problem
As per issue #255, there is currently no way to directly query for soft deleted objects

## Solution
Added a default Manager as `all_objects` on the SoftDeletableModel
