### PR TITLE
Don't default MonitorField to now

### DIFF
--- a/model_utils/fields.py
+++ b/model_utils/fields.py
@@ -89,7 +89,6 @@ class MonitorField(models.DateTimeField):
 
     """
     def __init__(self, *args, **kwargs):
-        kwargs.setdefault('default', now)
         monitor = kwargs.pop('monitor', None)
         if not monitor:
             raise TypeError(

--- a/tests/models.py
+++ b/tests/models.py
@@ -85,7 +85,7 @@ class TimeFrameManagerAdded(TimeFramedModel):
 
 class Monitored(models.Model):
     name = models.CharField(max_length=25)
-    name_changed = MonitorField(monitor="name")
+    name_changed = MonitorField(monitor="name", blank=True, null=True)
 
 
 class MonitorWhen(models.Model):


### PR DESCRIPTION
## Problem

If you don't explicitly set `default=None` where you use `MonitorField` migrations will default all existing instances to `now`, as will new instances.

IMHO this doesn't make sense since the monitored field didn't change.

## Solution

Remove `kwargs.setdefault('default', now)`

## Commandments

- [x] Write PEP8 compliant code.
- [ ] Cover it with tests.
- [ ] Update `CHANGES.rst` file to describe the changes, and quote according issue with `GH-<issue_number>`.
- [ ] Pay attention to backward compatibility, or if it breaks it, explain why.
- [ ] Update documentation (if relevant).

(will check the boxes after confirmation this is an acceptable change)
