### PR TITLE
Fix missing subclasses and annotated in cloned InheritanceQueryset

### DIFF
--- a/model_utils/managers.py
+++ b/model_utils/managers.py
@@ -98,7 +98,11 @@ class InheritanceQuerySetMixin(object):
 
     def _clone(self, klass=None, setup=False, **kwargs):
         if django.VERSION >= (2, 0):
-            return super(InheritanceQuerySetMixin, self)._clone()
+            qs = super(InheritanceQuerySetMixin, self)._clone()
+            for name in ['subclasses', '_annotated']:
+                if hasattr(self, name):
+                    setattr(qs, name, getattr(self, name))
+            return qs
 
         for name in ['subclasses', '_annotated']:
             if hasattr(self, name):

--- a/tests/test_managers/test_inheritance_manager.py
+++ b/tests/test_managers/test_inheritance_manager.py
@@ -451,3 +451,7 @@ class InheritanceManagerRelatedTests(InheritanceManagerTests):
         qs = InheritanceManagerTestParent.objects.annotate(
             test_count=models.Count('id')).select_subclasses()
         self.assertEqual(qs.get(id=self.child1.id).test_count, 1)
+
+    def test_clone_when_inheritance_queryset_selects_subclasses_should_clone_them_too(self):
+        qs = InheritanceManagerTestParent.objects.select_subclasses()
+        self.assertEqual(qs.subclasses, qs._clone().subclasses)


### PR DESCRIPTION
## Problem

In django versions above 2 `_clone` function does not copy the `subclasses` and `annotated` fields. 

## Solution

Copy the attributes `subclasses` and `annotated` after queryset clone

## Commandments

- [x] Write PEP8 compliant code.
- [x] Cover it with tests.
- [ ] Update `CHANGES.rst` file to describe the changes, and quote according issue with `GH-<issue_number>`.
- [x] Pay attention to backward compatibility, or if it breaks it, explain why.
- [x] Update documentation (if relevant).
