### PR TITLE
Only wrap deferred attributes

### DIFF
--- a/model_utils/tracker.py
+++ b/model_utils/tracker.py
@@ -216,9 +216,10 @@ class FieldTracker(object):
         if django.VERSION >= (1, 10):
             for field_name in self.fields:
                 descriptor = getattr(sender, field_name)
-                wrapper_cls = DescriptorWrapper.cls_for_descriptor(descriptor)
-                wrapped_descriptor = wrapper_cls(field_name, descriptor, self.attname)
-                setattr(sender, field_name, wrapped_descriptor)
+                if isinstance(descriptor, DeferredAttribute):
+                    wrapper_cls = DescriptorWrapper.cls_for_descriptor(descriptor)
+                    wrapped_descriptor = wrapper_cls(field_name, descriptor, self.attname)
+                    setattr(sender, field_name, wrapped_descriptor)
         self.field_map = self.get_field_map(sender)
         models.signals.post_init.connect(self.initialize_tracker)
         self.model_class = sender

--- a/tests/models.py
+++ b/tests/models.py
@@ -210,7 +210,14 @@ class FeaturedManager(models.Manager):
         return ByAuthorQuerySet(self.model, **kwargs).filter(feature=True)
 
 
-class Tracked(models.Model):
+class TrackedAbstract(models.Model):
+    number = 1
+
+    class Meta:
+        abstract = True
+
+
+class Tracked(TrackedAbstract):
     name = models.CharField(max_length=20)
     number = models.IntegerField()
     mutable = MutableField(default=None)


### PR DESCRIPTION
## Problem

Fixes #331.

## Solution

This only wraps field descriptors if they are deferred attributes.

## Commandments

- [x] Write PEP8 compliant code.
- [ ] Cover it with tests.
- [ ] Update `CHANGES.rst` file to describe the changes, and quote according issue with `GH-<issue_number>`.
- [ ] Pay attention to backward compatibility, or if it breaks it, explain why.
- [ ] Update documentation (if relevant).
