### PR TITLE
fix #330 patch MyModel.save instead of MyModel().save

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ master (unreleased)
 - Fix handling of deferred attributes on Django 1.10+, fixes GH-278
 - Fix `FieldTracker.has_changed()` and `FieldTracker.previous()` to return
   correct responses for deferred fields.
+- Fix Model instance non picklable GH-330
 
 3.1.2 (2018.05.09)
 ------------------

--- a/model_utils/tracker.py
+++ b/model_utils/tracker.py
@@ -207,6 +207,7 @@ class FieldTracker(object):
     def contribute_to_class(self, cls, name):
         self.name = name
         self.attname = '_%s' % name
+        self.patch_save(cls)
         models.signals.class_prepared.connect(self.finalize_class, sender=cls)
 
     def finalize_class(self, sender, **kwargs):
@@ -230,14 +231,13 @@ class FieldTracker(object):
         tracker = self.tracker_class(instance, self.fields, self.field_map)
         setattr(instance, self.attname, tracker)
         tracker.set_saved_fields()
-        self.patch_save(instance)
         instance._instance_intialized = True
 
-    def patch_save(self, instance):
-        original_save = instance.save
+    def patch_save(self, model):
+        original_save = model.save
 
-        def save(**kwargs):
-            ret = original_save(**kwargs)
+        def save(instance, **kwargs):
+            ret = original_save(instance, **kwargs)
             update_fields = kwargs.get('update_fields')
             if not update_fields and update_fields is not None:  # () or []
                 fields = update_fields
@@ -248,12 +248,12 @@ class FieldTracker(object):
                     field for field in update_fields if
                     field in self.fields
                 )
-            getattr(instance, self.attname).set_saved_fields(
+            getattr(model, self.attname).set_saved_fields(
                 fields=fields
             )
             return ret
 
-        instance.save = save
+        model.save = save
 
     def __get__(self, instance, owner):
         if instance is None:

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -11,6 +11,6 @@ SECRET_KEY = 'dummy'
 
 CACHES = {
     'default': {
-        'BACKEND': 'django.core.cache.backends.dummy.LocMemCache',
+        'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
     }
 }

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -8,3 +8,9 @@ DATABASES = {
     }
 }
 SECRET_KEY = 'dummy'
+
+CACHES = {
+    'default': {
+        'BACKEND': 'django.core.cache.backends.dummy.LocMemCache',
+    }
+}

--- a/tests/test_fields/test_field_tracker.py
+++ b/tests/test_fields/test_field_tracker.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 import django
 from django.core.exceptions import FieldError
 from django.test import TestCase
-
+from django.core.cache import cache
 from model_utils import FieldTracker
 from model_utils.tracker import DescriptorWrapper
 from tests.models import (
@@ -64,6 +64,15 @@ class FieldTrackerTests(FieldTrackerTestCase, FieldTrackerCommonTests):
 
     def test_descriptor(self):
         self.assertTrue(isinstance(self.tracked_class.tracker, FieldTracker))
+
+    def test_cache_compatible(self):
+        cache.set('key', self.instance)
+        instance = cache.get('key')
+        instance.save()
+        self.assertChanged()
+        prev = instance.name
+        instance.name = 'new age'
+        self.assertChanged(name=prev)
 
     def test_pre_save_changed(self):
         self.assertChanged(name=None)

--- a/tests/test_fields/test_field_tracker.py
+++ b/tests/test_fields/test_field_tracker.py
@@ -72,6 +72,7 @@ class FieldTrackerTests(FieldTrackerTestCase, FieldTrackerCommonTests):
         self.assertChanged()
         prev = instance.name
         instance.name = 'new age'
+        instance.number = 8
         self.assertChanged(name=prev)
 
     def test_pre_save_changed(self):


### PR DESCRIPTION
## Problem

see #330 for more details, shortly:
`AttributeError: Can't pickle local object 'FieldTracker.patch_save.<locals>.save'`

## Solution

Original code stored patched `save` method in `instance.__dict__`, breaking django cache system. 
PR proposes to patch model class save instead at `FieldTracker.contribute_to_class`.

## Commandments

- [x] Write PEP8 compliant code.
- [x] Cover it with tests.
- [x] Update `CHANGES.rst` file to describe the changes, and quote according issue with `GH-<issue_number>`.
- [x] Pay attention to backward compatibility, or if it breaks it, explain why.
- [x] Update documentation (if relevant).
