### PR TITLE
fix #330 patch MyModel.save instead of MyModel().save

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ master (unreleased)
 - Fix handling of deferred attributes on Django 1.10+, fixes GH-278
 - Fix `FieldTracker.has_changed()` and `FieldTracker.previous()` to return
   correct responses for deferred fields.
+- Fix Model instance non picklable GH-330
 
 3.1.2 (2018.05.09)
 ------------------

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -8,3 +8,9 @@ DATABASES = {
     }
 }
 SECRET_KEY = 'dummy'
+
+CACHES = {
+    'default': {
+        'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
+    }
+}

--- a/tests/test_fields/test_field_tracker.py
+++ b/tests/test_fields/test_field_tracker.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 import django
 from django.core.exceptions import FieldError
 from django.test import TestCase
-
+from django.core.cache import cache
 from model_utils import FieldTracker
 from model_utils.tracker import DescriptorWrapper
 from tests.models import (
@@ -638,6 +638,16 @@ class FieldTrackerFileFieldTests(FieldTrackerTestCase):
 class ModelTrackerTests(FieldTrackerTests):
 
     tracked_class = ModelTracked
+
+    def test_cache_compatible(self):
+        cache.set('key', self.instance)
+        instance = cache.get('key')
+        instance.number = 1
+        instance.name = 'cached'
+        instance.save()
+        self.assertChanged()
+        instance.number = 2
+        self.assertHasChanged(number=True)
 
     def test_pre_save_changed(self):
         self.assertChanged()


### PR DESCRIPTION
## Problem

see #330 for more details, shortly:
`AttributeError: Can't pickle local object 'FieldTracker.patch_save.<locals>.save'`

## Solution

Original code stored patched `save` method in `instance.__dict__`, breaking django cache system. 
PR proposes to patch model class save instead at `FieldTracker.contribute_to_class`.

## Commandments

- [x] Write PEP8 compliant code.
- [x] Cover it with tests.
- [x] Update `CHANGES.rst` file to describe the changes, and quote according issue with `GH-<issue_number>`.
- [x] Pay attention to backward compatibility, or if it breaks it, explain why.
- [x] Update documentation (if relevant).
