### PR TITLE
fix model.save patched in FieldTracker

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,7 @@ master (unreleased)
   always be set equal to created to make querying easier. Fixes GH-254
 - Support `reversed` for all kinds of `Choices` objects, fixes GH-309
 - Fix Model instance non picklable GH-330
+- Fix patched `save` in FieldTracker
 
 3.1.2 (2018.05.09)
 ------------------

--- a/model_utils/tracker.py
+++ b/model_utils/tracker.py
@@ -236,8 +236,8 @@ class FieldTracker(object):
     def patch_save(self, model):
         original_save = model.save
 
-        def save(instance, **kwargs):
-            ret = original_save(instance, **kwargs)
+        def save(instance, *args, **kwargs):
+            ret = original_save(instance, *args, **kwargs)
             update_fields = kwargs.get('update_fields')
             if not update_fields and update_fields is not None:  # () or []
                 fields = update_fields

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -10,6 +10,7 @@ DATABASES = {
         "NAME": os.environ.get("DJANGO_DATABASE_NAME_POSTGRES", "modelutils"),
         "USER": os.environ.get("DJANGO_DATABASE_USER_POSTGRES", 'postgres'),
         "PASSWORD": os.environ.get("DJANGO_DATABASE_PASSWORD_POSTGRES", ""),
+        "HOST": os.environ.get("DJANGO_DATABASE_HOST_POSTGRES", ""),
     },
 }
 SECRET_KEY = 'dummy'

--- a/tests/test_fields/test_field_tracker.py
+++ b/tests/test_fields/test_field_tracker.py
@@ -85,6 +85,11 @@ class FieldTrackerTests(FieldTrackerTestCase, FieldTrackerCommonTests):
         self.instance.mutable = [1, 2, 3]
         self.assertHasChanged(name=True, number=True, mutable=True)
 
+    def test_save_with_args(self):
+        self.instance.number = 1
+        self.instance.save(False, False, None, None)
+        self.assertChanged()
+
     def test_first_save(self):
         self.assertHasChanged(name=True, number=False, mutable=False)
         self.assertPrevious(name=None, number=None, mutable=None)


### PR DESCRIPTION
## Problem

After #350 django model with tracker can't call save with args:
```
    return super().save(force_insert, force_update, using, update_fields)
TypeError: save() takes 1 positional argument but 5 were given 
```
## Solution

Add `*args` to patched_save.

## Commandments

- [x] Write PEP8 compliant code.
- [x] Cover it with tests.
- [x] Update `CHANGES.rst` file to describe the changes, and quote according issue with `GH-<issue_number>`.
- [x] Pay attention to backward compatibility, or if it breaks it, explain why.
- [x] Update documentation (if relevant).
