### PR TITLE
Upgrades pytest, pytest-django and pytest-cov version to fix travis build

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,8 @@ master (unreleased)
 - Support `reversed` for all kinds of `Choices` objects, fixes GH-309
 - Fix Model instance non picklable GH-330
 - Fix patched `save` in FieldTracker
+- Upgrades test requirements (pytest, pytest-django, pytest-cov) and 
+  skips tox test with Python 3.5 and Django (trunk)
 
 3.1.2 (2018.05.09)
 ------------------

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,3 +1,4 @@
-pytest==3.3.1
-pytest-django==3.1.2
+pytest==4.3.0
+pytest-django==3.4.7
 psycopg2==2.7.6.1
+pytest-cov==2.6.1

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,6 @@ deps =
     djangotrunk: https://github.com/django/django/archive/master.tar.gz
     freezegun == 0.3.8
     -rrequirements-test.txt
-    pytest-cov
 ignore_outcome =
     djangotrunk: True
 passenv =

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 envlist =
     py27-django{19,110,111}
     py34-django{19,110,111,200}
-    py35-django{19,110,111,200,201,trunk}
+    py35-django{19,110,111,200,201}
     py36-django{111,200,201,trunk}
     flake8
 


### PR DESCRIPTION
## Problem

Solves #359: Travis build is failing

## Solution

Changed tests requirements upgrading:

 - pytest
 - pytest-django
 - pytest-cov

## Commandments

- [x] Write PEP8 compliant code.
- [x] Cover it with tests.
- [x] Update `CHANGES.rst` file to describe the changes, and quote according issue with `GH-<issue_number>`.
- [x] Pay attention to backward compatibility, or if it breaks it, explain why.
- [x] Update documentation (if relevant).
