### PR TITLE
managers: honor OneToOneField.parent_link=False

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,7 @@ CHANGES
 
 master (unreleased)
 -------------------
+- Honor `OneToOneField.parent_link=False`.
 - Fix handling of deferred attributes on Django 1.10+, fixes GH-278
 - Fix `FieldTracker.has_changed()` and `FieldTracker.previous()` to return
   correct responses for deferred fields.

--- a/model_utils/managers.py
+++ b/model_utils/managers.py
@@ -158,6 +158,7 @@ class InheritanceQuerySetMixin(object):
             if isinstance(rel.field, OneToOneField)
             and issubclass(rel.field.model, model)
             and model is not rel.field.model
+            and rel.parent_link
         ]
 
         subclasses = []

--- a/tests/models.py
+++ b/tests/models.py
@@ -73,6 +73,16 @@ class InheritanceManagerTestChild3(InheritanceManagerTestParent):
         InheritanceManagerTestParent, related_name='manual_onetoone',
         parent_link=True, on_delete=models.CASCADE)
 
+class InheritanceManagerTestChild4(InheritanceManagerTestParent):
+    other_onetoone = models.OneToOneField(
+        InheritanceManagerTestParent, related_name='non_inheritance_relation',
+        parent_link=False, on_delete=models.CASCADE)
+    # The following is needed because of that Django bug:
+    # https://code.djangoproject.com/ticket/29998
+    parent_ptr = models.OneToOneField(
+        InheritanceManagerTestParent, related_name='child4_onetoone',
+        parent_link=True, on_delete=models.CASCADE)
+
 
 class TimeStamp(TimeStampedModel):
     pass

--- a/tests/test_managers/test_inheritance_manager.py
+++ b/tests/test_managers/test_inheritance_manager.py
@@ -10,7 +10,8 @@ from tests.models import (
     InheritanceManagerTestRelated, InheritanceManagerTestGrandChild1,
     InheritanceManagerTestGrandChild1_2, InheritanceManagerTestParent,
     InheritanceManagerTestChild1,
-    InheritanceManagerTestChild2, TimeFrame, InheritanceManagerTestChild3
+    InheritanceManagerTestChild2, TimeFrame, InheritanceManagerTestChild3,
+    InheritanceManagerTestChild4,
 )
 
 
@@ -141,6 +142,7 @@ class InheritanceManagerTests(TestCase):
             'inheritancemanagertestchild1',
             'inheritancemanagertestchild2',
             'manual_onetoone',  # this was set via parent_link & related_name
+            'child4_onetoone',
         ]
         self.assertEqual(set(results.subclasses),
                          set(expected_related_names))
@@ -258,7 +260,7 @@ class InheritanceManagerUsingModelsTests(TestCase):
         objs = InheritanceManagerTestParent.objects.select_subclasses().order_by('pk')
         objsmodels = InheritanceManagerTestParent.objects.select_subclasses(
             InheritanceManagerTestChild1, InheritanceManagerTestChild2,
-            InheritanceManagerTestChild3,
+            InheritanceManagerTestChild3, InheritanceManagerTestChild4,
             InheritanceManagerTestGrandChild1,
             InheritanceManagerTestGrandChild1_2).order_by('pk')
         self.assertEqual(set(objs.subclasses), set(objsmodels.subclasses))
@@ -280,6 +282,7 @@ class InheritanceManagerUsingModelsTests(TestCase):
         models = (InheritanceManagerTestChild1,
                   InheritanceManagerTestChild2,
                   InheritanceManagerTestChild3,
+                  InheritanceManagerTestChild4,
                   InheritanceManagerTestGrandChild1,
                   InheritanceManagerTestGrandChild1_2)
 


### PR DESCRIPTION
## Problem

If a child model needs a `OneToOneField` with any of its parent class that use `InheritanceManager` along with the usual `parent_link` generated by Django, `model_utils` adds by mistake the reverse link of this relation to the usual list of possible subclasses. Depending of the length of the classes names, and the depth of the class tree, a bug may be triggered or not, resulting in a child object being cast to the wrong class (basically one with a longer name).

## Solution

When building the list of possible subclasses, check that `parent_link` is `True` before adding the class to the list.

## Commandments

- [x] Write PEP8 compliant code.
- [x] Cover it with tests.
- [x] Update `CHANGES.rst` file to describe the changes, and quote according issue with `GH-<issue_number>`.
- [x] Pay attention to backward compatibility, or if it breaks it, explain why.
- [ ] ~~Update documentation (if relevant).~~
