### PR TITLE
Move patch_save to finalize_class so it works on models with save() methods

### DIFF
--- a/model_utils/tracker.py
+++ b/model_utils/tracker.py
@@ -210,7 +210,6 @@ class FieldTracker(object):
     def contribute_to_class(self, cls, name):
         self.name = name
         self.attname = '_%s' % name
-        self.patch_save(cls)
         models.signals.class_prepared.connect(self.finalize_class, sender=cls)
 
     def finalize_class(self, sender, **kwargs):
@@ -227,6 +226,7 @@ class FieldTracker(object):
         models.signals.post_init.connect(self.initialize_tracker)
         self.model_class = sender
         setattr(sender, self.name, self)
+        self.patch_save(sender)
 
     def initialize_tracker(self, sender, instance, **kwargs):
         if not isinstance(instance, self.model_class):

--- a/tests/models.py
+++ b/tests/models.py
@@ -238,6 +238,10 @@ class Tracked(models.Model):
 
     tracker = FieldTracker()
 
+    def save(self, *args, **kwargs):
+        """ No-op save() to ensure that FieldTracker.patch_save() works. """
+        super(Tracked, self).save(*args, **kwargs)
+
 
 class TrackedFK(models.Model):
     fk = models.ForeignKey('Tracked', on_delete=models.CASCADE)


### PR DESCRIPTION
## Problem

This fixes a regression added by #350. There is currently a non-deterministic failure to apply `FieldTracker.patch_save()` to models that have their own save method. For example:

```
class Tracked(models.Model):
    tracker = FieldTracker()
    def save(self, *args, **kwargs):
        super(Tracked, self).save(*args, **kwargs)
print(Tracked.save)
# May print correctly:
# <function model_utils.tracker.FieldTracker.patch_save.<locals>.save(instance, *args, **kwargs)>
# Or may print incorrectly:
# <function Tracked.save(self, *args, **kwargs)>
```

If `patch_save` fails, then the field tracker doesn't properly reset after calling save.

The reason for this nondeterminism is that Django's ModelBase metaclass (prior to 2.2) copies attributes to the model in dictionary order, so the `patch_save()` call in `FieldTracker. contribute_to_class` only lasts if `'save'` happens to come before `'tracker'` in the attr dictionary's keys.

(Here's the [Django code prior to 2.2](https://github.com/django/django/blob/stable/2.1.x/django/db/models/base.py#L138), and the [new Django 2.2 code](https://github.com/django/django/blob/03db5fddfd0c76303ec83eb1cd91a6d2dc4441cb/django/db/models/base.py#L155) that coincidentally happens to fix this bug by copying attributes in a different order.)

## Solution

This PR moves the `patch_save()` call to `finalize_class` so it runs after all attributes are copied over. It also adds a `save()` method to one of the test models, which causes the current code to fail as expected.

## Commandments

- [x] Write PEP8 compliant code.
- [x] Cover it with tests.
- [ ] Update `CHANGES.rst` file to describe the changes, and quote according issue with `GH-<issue_number>` -- not applicable, just fixing a regression in master.
- [x] Pay attention to backward compatibility, or if it breaks it, explain why.
- [x] Update documentation (if relevant).
