### PR TITLE
Release 3.2.0.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 CHANGES
 =======
 
-master (unreleased)
+3.2.0 (2019.06.21)
 -------------------
 - Catch `AttributeError` for deferred abstract fields, fixes GH-331.
 - Update documentation to explain usage of `timeframed` model manager, fixes GH-118


### PR DESCRIPTION
Planning on tagging this change with the `3.2.0` to kickoff the release process once it's merged.

Looks like version number was already bumped in https://github.com/jazzband/django-model-utils/commit/05671695bb347fea57fcf33c2f0897d918184819 but never release, not sure why.

Fixes #366
