### PR TITLE
Fixed flake8 issues.

### DIFF
--- a/model_utils/fields.py
+++ b/model_utils/fields.py
@@ -284,15 +284,15 @@ class UUIDField(models.UUIDField):
         ValidationError
             UUID version 2 is not supported.
         """
-        
+
         if version == 2:
             raise ValidationError(
                 'UUID version 2 is not supported.')
-            
+
         if version < 1 or version > 5:
             raise ValidationError(
                 'UUID version is not valid.')
-            
+
         if version == 1:
             default = uuid.uuid1
         elif version == 3:
@@ -300,8 +300,8 @@ class UUIDField(models.UUIDField):
         elif version == 4:
             default = uuid.uuid4
         elif version == 5:
-            default = uuid.uuid5  
-           
+            default = uuid.uuid5
+
         kwargs.setdefault('primary_key', primary_key)
         kwargs.setdefault('editable', editable)
         kwargs.setdefault('default', default)

--- a/model_utils/models.py
+++ b/model_utils/models.py
@@ -196,7 +196,7 @@ class SaveSignalHandlingModel(models.Model):
         if cls._meta.proxy:
             cls = cls._meta.concrete_model
         meta = cls._meta
-        if not meta.auto_created and not 'pre_save' in self.signals_to_disable:
+        if not meta.auto_created and 'pre_save' not in self.signals_to_disable:
             pre_save.send(
                 sender=origin, instance=self, raw=raw, using=using,
                 update_fields=update_fields,
@@ -209,7 +209,7 @@ class SaveSignalHandlingModel(models.Model):
         self._state.db = using
         self._state.adding = False
 
-        if not meta.auto_created and not 'post_save' in self.signals_to_disable:
+        if not meta.auto_created and 'post_save' not in self.signals_to_disable:
             post_save.send(
                 sender=origin, instance=self, created=(not updated),
                 update_fields=update_fields, raw=raw, using=using,

--- a/model_utils/models.py
+++ b/model_utils/models.py
@@ -107,8 +107,8 @@ def add_timeframed_query_manager(sender, **kwargs):
             % sender.__name__
         )
     sender.add_to_class('timeframed', QueryManager(
-        (models.Q(start__lte=now) | models.Q(start__isnull=True)) &
-        (models.Q(end__gte=now) | models.Q(end__isnull=True))
+        (models.Q(start__lte=now) | models.Q(start__isnull=True))
+        & (models.Q(end__gte=now) | models.Q(end__isnull=True))
     ))
 
 

--- a/tests/models.py
+++ b/tests/models.py
@@ -80,6 +80,7 @@ class InheritanceManagerTestChild3(InheritanceManagerTestParent):
         InheritanceManagerTestParent, related_name='manual_onetoone',
         parent_link=True, on_delete=models.CASCADE)
 
+
 class InheritanceManagerTestChild4(InheritanceManagerTestParent):
     other_onetoone = models.OneToOneField(
         InheritanceManagerTestParent, related_name='non_inheritance_relation',

--- a/tests/models.py
+++ b/tests/models.py
@@ -4,7 +4,6 @@ import django
 from django.db import models
 from django.db.models.query_utils import DeferredAttribute
 from django.db.models import Manager
-from django.dispatch import receiver
 from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _
 

--- a/tests/signals.py
+++ b/tests/signals.py
@@ -1,5 +1,6 @@
 def pre_save_test(instance, *args, **kwargs):
     instance.pre_save_runned = True
 
+
 def post_save_test(instance, created, *args, **kwargs):
     instance.post_save_runned = True

--- a/tests/test_models/test_savesignalhandling_model.py
+++ b/tests/test_models/test_savesignalhandling_model.py
@@ -26,7 +26,6 @@ class SaveSignalHandlingModelTests(TestCase):
         self.assertEqual(obj.name, 'Test B')
         self.assertFalse(hasattr(obj, 'pre_save_runned'))
 
-
     def test_post_save(self):
         post_save.connect(post_save_test, sender=SaveSignalHandlingTestModel)
 


### PR DESCRIPTION
## Problem

```
model_utils/fields.py:287:1: W293 blank line contains whitespace
model_utils/fields.py:291:1: W293 blank line contains whitespace
model_utils/fields.py:295:1: W293 blank line contains whitespace
model_utils/fields.py:303:33: W291 trailing whitespace
model_utils/fields.py:304:1: W293 blank line contains whitespace
model_utils/models.py:110:67: W504 line break after binary operator
model_utils/models.py:199:38: E713 test for membership should be 'not in'
model_utils/models.py:212:38: E713 test for membership should be 'not in'
tests/signals.py:4:1: E302 expected 2 blank lines, found 1
tests/models.py:7:1: F401 'django.dispatch.receiver' imported but unused
tests/models.py:84:1: E302 expected 2 blank lines, found 1
tests/test_models/test_savesignalhandling_model.py:30:5: E303 too many blank lines (2)
```

## Solution

No functionality changes, just did what was needed to cheer up `flake8`, (as invoked by `tox`).

## Commandments

- [x] Write PEP8 compliant code.
- [x] Cover it with tests.
- [ ] Update `CHANGES.rst` file to describe the changes, and quote according issue with `GH-<issue_number>`. - Not required.
- [x] Pay attention to backward compatibility, or if it breaks it, explain why.
- [x] Update documentation (if relevant).
