### PR TITLE
Replace deprecated `django.utils.six` module with `six` library

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -54,3 +54,4 @@
 | Zach Cheung <kuroro.zhang@gmail.com>
 | Daniel Andrlik <daniel@andrlik.org>
 | marfyl <github.com/marfyl>
+| Chris Cameron <github.com/unchris>

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ CHANGES
 ------------------
 
 - Remove hacks for previously supported Django versions. (Fixes GH-390)
+- Changed to use `six` directly instead of `django.utils.six` which was deprecated and will be removed in Django 3
+- removed import of `with_metaclass` which was not used
+- Added python3.7/Django3alpha test targets to tox
 
 3.3.0 (2019.08.19)
 ------------------

--- a/model_utils/fields.py
+++ b/model_utils/fields.py
@@ -5,7 +5,7 @@ import uuid
 from django.db import models
 from django.conf import settings
 from django.core.exceptions import ValidationError
-from django.utils.encoding import python_2_unicode_compatible
+from six import python_2_unicode_compatible
 from django.utils.timezone import now
 
 DEFAULT_CHOICES_NAME = 'STATUS'

--- a/model_utils/managers.py
+++ b/model_utils/managers.py
@@ -7,7 +7,7 @@ from django.db.models.query import ModelIterable
 from django.core.exceptions import ObjectDoesNotExist
 
 from django.db.models.constants import LOOKUP_SEP
-from django.utils.six import string_types
+from six import string_types
 
 from django.db import connection
 from django.db.models.sql.datastructures import Join
@@ -197,11 +197,11 @@ class InheritanceQuerySet(InheritanceQuerySetMixin, QuerySet):
         """
         # If we aren't already selecting the subclasess, we need
         # to in order to get this to work.
-        
+
         # How can we tell if we are not selecting subclasses?
-        
+
         # Is it safe to just apply .select_subclasses(*models)?
-        
+
         # Due to https://code.djangoproject.com/ticket/16572, we
         # can't really do this for anything other than children (ie,
         # no grandchildren+).
@@ -213,7 +213,7 @@ class InheritanceQuerySet(InheritanceQuerySetMixin, QuerySet):
                     field.attname, # Should this be something else?
                 ) for field in model._meta.parents.values()
             ]) + ')')
-        
+
         return self.select_subclasses(*models).extra(where=[' OR '.join(where_queries)])
 
 class InheritanceManagerMixin(object):

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ tox
 sphinx
 twine
 freezegun
+six

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,10 @@ setup(
     maintainer='JazzBand',
     url='https://github.com/jazzband/django-model-utils/',
     packages=find_packages(exclude=['tests*']),
-    install_requires=['Django>=1.11'],
+    install_requires=[
+        'Django >= 1.11',
+        'six >= 1.10.0'
+    ],
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Environment :: Web Environment',

--- a/tests/fields.py
+++ b/tests/fields.py
@@ -1,6 +1,6 @@
 import django
 from django.db import models
-from django.utils.six import with_metaclass, string_types
+from six import string_types
 
 
 def mutable_from_db(value):

--- a/tests/models.py
+++ b/tests/models.py
@@ -4,7 +4,7 @@ import django
 from django.db import models
 from django.db.models.query_utils import DeferredAttribute
 from django.db.models import Manager
-from django.utils.encoding import python_2_unicode_compatible
+from six import python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _
 
 from model_utils import Choices

--- a/tests/test_fields/test_split_field.py
+++ b/tests/test_fields/test_split_field.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals
 
-from django.utils.six import text_type
+from six import text_type
 from django.test import TestCase
 
 from tests.models import Article, SplitFieldAbstractParent

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,7 @@ envlist =
     py27-django{111}
     py37-django{202,201}
     py36-django{111,202,201,trunk}
+    py37-django30
     flake8
 
 [testenv]
@@ -10,6 +11,7 @@ deps =
     django111: Django>=1.11,<1.12
     django202: Django>=2.2,<3.0
     django201: Django>=2.1,<2.2
+    django30: Django~=3.0a1
     djangotrunk: https://github.com/django/django/archive/master.tar.gz
     freezegun == 0.3.8
     -rrequirements-test.txt


### PR DESCRIPTION
## Problem

I am preparing an application for Django 3 support using Django 3.0a1. I've noticed that `django-model-utils` still uses `django.utils.six` which is deprecated and removed in Django 3. 

## Solution

I replaced `django.utils.six` with `six` which can be fetched from pypi as usual. Added Python3/Django3 test target to `tox` (I'm not an expert at `tox` setup so please advise if I've screwed that up). 

## Commandments

- [x] Write PEP8 compliant code.
- [x] Cover it with tests.
- [x] Update `CHANGES.rst` file to describe the changes, and quote according issue with `GH-<issue_number>`.
- [x] Pay attention to backward compatibility, or if it breaks it, explain why.
- [x] Update documentation (if relevant).
