### PR TITLE
patch Model.refresh_from_db in FieldTracker

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,7 +3,7 @@ CHANGES
 
 4.0.1 (unreleased)
 ------------------
-- No changes yet
+- `FieldTracker` now marks fields as not changed after `refresh_from_db`
 
 4.0.0 (2019-12-11)
 ------------------

--- a/tests/test_fields/test_field_tracker.py
+++ b/tests/test_fields/test_field_tracker.py
@@ -178,6 +178,22 @@ class FieldTrackerTests(FieldTrackerTestCase, FieldTrackerCommonTests):
         self.assertEqual(in_db.number, self.instance.number)
         self.assertEqual(in_db.mutable, self.instance.mutable)
 
+    def test_refresh_from_db(self):
+        self.update_instance(name='retro', number=4, mutable=[1, 2, 3])
+        self.tracked_class.objects.filter(pk=self.instance.pk).update(
+            name='new age', number=8, mutable=[3, 2, 1])
+        self.assertChanged()
+        self.instance.name = 'like in db'
+        self.instance.number = 8
+        self.instance.mutable = [3, 2, 1]
+        self.assertChanged(name='retro', number=4, mutable=[1, 2, 3])
+        self.instance.refresh_from_db(fields=('name',))
+        self.assertChanged(number=4, mutable=[1, 2, 3])
+        self.instance.refresh_from_db(fields={'mutable'})
+        self.assertChanged(number=4)
+        self.instance.refresh_from_db()
+        self.assertChanged()
+
     def test_with_deferred(self):
         self.instance.name = 'new age'
         self.instance.number = 1


### PR DESCRIPTION
## Problem

FieldTracker does not track changes received with refresh_from_db. Steps to reproduce:

* update model instance "somewhere else": `Model.objects.filter(pk=obj.pk).update(field='new_in_db')`
* call `obj.refresh_from_db` with instance that is not syncrhonized with current db state
* `obj.field` is now marked as changed from 'old_py_value' to 'new_in_db', but really 'new_in_db' value is same in obj and in db

Mostly this bug affects test as a place of numerous `refresh_from_db` calls, but any pair of `refresh_fom_db()` + `tracker.changed()` may be incorrect.

## Solution

Patch Model.refresh_from_db the same way as Model.save is patched in FieldTracker.

## Commandments

- [x] Write PEP8 compliant code.
- [x] Cover it with tests.
- [x] Update `CHANGES.rst` file to describe the changes, and quote according issue with `GH-<issue_number>`.
- [x] Pay attention to backward compatibility, or if it breaks it, explain why.
- [x] Update documentation (if relevant).
