### PR TITLE
FieldTracker should patch save_base instead of save 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ CHANGES
 4.0.1 (unreleased)
 ------------------
 - `FieldTracker` now marks fields as not changed after `refresh_from_db`
+- `FieldTracker` now respects `update_fields` changed in overridden `save()`
+  method
 
 4.0.0 (2019-12-11)
 ------------------

--- a/model_utils/tracker.py
+++ b/model_utils/tracker.py
@@ -234,7 +234,7 @@ class FieldTracker:
         instance._instance_intialized = True
 
     def patch_save(self, model):
-        self._patch(model, 'save', 'update_fields')
+        self._patch(model, 'save_base', 'update_fields')
         self._patch(model, 'refresh_from_db', 'fields')
 
     def _patch(self, model, method, fields_kwarg):

--- a/tests/models.py
+++ b/tests/models.py
@@ -247,6 +247,21 @@ class Tracked(models.Model):
         super().save(*args, **kwargs)
 
 
+class TrackerTimeStamped(TimeStampedModel):
+    name = models.CharField(max_length=20)
+    number = models.IntegerField()
+    mutable = MutableField(default=None)
+
+    tracker = FieldTracker()
+
+    def save(self, *args, **kwargs):
+        """ Automatically add "modified" to update_fields."""
+        update_fields = kwargs.get('update_fields')
+        if update_fields is not None:
+            kwargs['update_fields'] = set(update_fields) | {'modified'}
+        super().save(*args, **kwargs)
+
+
 class TrackedFK(models.Model):
     fk = models.ForeignKey('Tracked', on_delete=models.CASCADE)
 

--- a/tests/test_fields/test_field_tracker.py
+++ b/tests/test_fields/test_field_tracker.py
@@ -6,7 +6,7 @@ from model_utils import FieldTracker
 from model_utils.tracker import DescriptorWrapper
 from tests.models import (
     Tracked, TrackedFK, InheritedTrackedFK, TrackedNotDefault, TrackedNonFieldAttr, TrackedMultiple,
-    InheritedTracked, TrackedFileField, TrackedAbstract,
+    InheritedTracked, TrackedFileField, TrackedAbstract, TrackerTimeStamped,
     ModelTracked, ModelTrackedFK, ModelTrackedNotDefault, ModelTrackedMultiple, InheritedModelTracked,
 )
 
@@ -521,6 +521,30 @@ class FieldTrackerForeignKeyTests(FieldTrackerTestCase):
         self.assertChanged(fk=self.old_fk.id)
         self.assertPrevious(fk=self.old_fk.id)
         self.assertCurrent(fk=self.instance.fk_id)
+
+
+class FieldTrackerTimeStampedTests(FieldTrackerTestCase):
+
+    fk_class = Tracked
+    tracked_class = TrackerTimeStamped
+
+    def setUp(self):
+        self.instance = self.tracked_class.objects.create(name='old', number=1)
+        self.tracker = self.instance.tracker
+
+    def test_set_modified_on_save(self):
+        old_modified = self.instance.modified
+        self.instance.name = 'new'
+        self.instance.save()
+        self.assertGreater(self.instance.modified, old_modified)
+        self.assertChanged()
+
+    def test_set_modified_on_save_update_fields(self):
+        old_modified = self.instance.modified
+        self.instance.name = 'new'
+        self.instance.save(update_fields=('name',))
+        self.assertGreater(self.instance.modified, old_modified)
+        self.assertChanged()
 
 
 class InheritedFieldTrackerTests(FieldTrackerTests):


### PR DESCRIPTION
## Problem

If model with `FieldTracker` adds extra fields to `update_fields` in `save`, these changes are not reflected in FieldTracker state.

## Solution

`FieldTracker` should patch `save_base` instead of `save`:
* `save_base` is called from `save` so final `update_fields` value is captured
* `save_base` is never overridden in `models.Model` subclasses

## Commandments

- [x] Write PEP8 compliant code.
- [x] Cover it with tests.
- [x] Update `CHANGES.rst` file to describe the changes, and quote according issue with `GH-<issue_number>`.
- [x] Pay attention to backward compatibility, or if it breaks it, explain why.
- [x] Update documentation (if relevant).
