### PR TITLE
Overriding TimeStampedModel's save() method

### DIFF
--- a/model_utils/models.py
+++ b/model_utils/models.py
@@ -35,7 +35,7 @@ class TimeStampedModel(models.Model):
         a parameter to the update field argument.
         """
         if 'update_fields' in kwargs and 'modified' not in kwargs['update_fields']:
-            kwargs['update_fields'].append('modified')
+            kwargs['update_fields'] += ['modified']
         super().save(*args, **kwargs)
         
     class Meta:

--- a/model_utils/models.py
+++ b/model_utils/models.py
@@ -28,6 +28,16 @@ class TimeStampedModel(models.Model):
     created = AutoCreatedField(_('created'))
     modified = AutoLastModifiedField(_('modified'))
 
+    def save(self, *args, **kwargs):
+        """
+        Overriding the save method in order to make sure that
+        modified field is updated even if it is not given as
+        a parameter to the update field argument.
+        """
+        if 'update_fields' in kwargs and 'modified' not in kwargs['update_fields']:
+            kwargs['update_fields'].append('modified')
+        super().save(*args, **kwargs)
+        
     class Meta:
         abstract = True
 

--- a/tests/test_models/test_timestamped_model.py
+++ b/tests/test_models/test_timestamped_model.py
@@ -90,3 +90,31 @@ class TimeStampedModelTests(TestCase):
         self.assertEqual(t1.created, different_date2)
         self.assertNotEqual(t1.modified, different_date2)
         self.assertNotEqual(t1.modified, different_date)
+    
+    def test_save_with_update_fields_overrides_modified_provided(self):
+        '''
+        Tests if the save method updated modified field
+        accordingly when update_fields is used as an argument
+        and modified is provided
+        '''
+        with freeze_time(datetime(2020,1,1)):
+            t1 = TimeStamp.objects.create()
+        
+        with freeze_time(datetime(2020,1,2)):
+            t1.save(update_fields=['modified'])
+        
+        self.assertEqual(t1.modified, datetime(2020,1,2))
+        
+    def test_save_with_update_fields_overrides_modified_not_provided(self):
+        '''
+        Tests if the save method updated modified field
+        accordingly when update_fields is used as an argument
+        and modified is not provided
+        '''
+        with freeze_time(datetime(2020,1,1)):
+            t1 = TimeStamp.objects.create()
+            
+        with freeze_time(datetime(2020,1,2)):
+            t1.save(update_fields=[])
+            
+        self.assertEqual(t1.modified, datetime(2020,1,2))


### PR DESCRIPTION
to update modified field automatically when update_fields argument is used but modified was not given as a parameter.

## Problem

When the save method was called with the 'update_fields' argument, the 'modified' field was not automatically updated when it was forgotten to be given as a parameter. This may lead to future confusion since developers may not be aware of this functionality, and it is more logical to expect this field to be updated even if it is not provided inside the 'update_fields'

## Solution

I've overrided the save method of the TimeStampedModel in order to support this functionality.

## Commandments

Unit tests on our product Plentific seems to work fine and as expected. 
