### PR TITLE
Satisfy deprecation warning under Django 3.0.3

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ CHANGES
 - `FieldTracker` now marks fields as not changed after `refresh_from_db`
 - `FieldTracker` now respects `update_fields` changed in overridden `save()`
   method
+- Replace ugettext_lazy with gettext_lazy to satisfy Django deprecation warning
 
 4.0.0 (2019-12-11)
 ------------------

--- a/model_utils/models.py
+++ b/model_utils/models.py
@@ -1,7 +1,7 @@
 from django.core.exceptions import ImproperlyConfigured
 from django.db import models, transaction, router
 from django.db.models.signals import post_save, pre_save
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from model_utils.fields import (
     AutoCreatedField,


### PR DESCRIPTION
## Problem

There is a deprecation warning for uggettext_lazy when running under Django 3.0.3.

`/home/martin/wks/redacted/venv3/lib/python3.6/site-packages/model_utils/models.py:28: RemovedInDjango40Warning: django.utils.translation.ugettext_lazy() is deprecated in favor of django.utils.translation.gettext_lazy().
  created = AutoCreatedField(_('created'))
/home/martin/wks/redacted/venv3/lib/python3.6/site-packages/model_utils/models.py:29: RemovedInDjango40Warning: django.utils.translation.ugettext_lazy() is deprecated in favor of django.utils.translation.gettext_lazy().
  modified = AutoLastModifiedField(_('modified'))
/home/martin/wks/redacted/venv3/lib/python3.6/site-packages/model_utils/models.py:41: RemovedInDjango40Warning: django.utils.translation.ugettext_lazy() is deprecated in favor of django.utils.translation.gettext_lazy().
  start = models.DateTimeField(_('start'), null=True, blank=True)
/home/martin/wks/redacted/venv3/lib/python3.6/site-packages/model_utils/models.py:42: RemovedInDjango40Warning: django.utils.translation.ugettext_lazy() is deprecated in favor of django.utils.translation.gettext_lazy().
  end = models.DateTimeField(_('end'), null=True, blank=True)
/home/martin/wks/redacted/venv3/lib/python3.6/site-packages/model_utils/models.py:57: RemovedInDjango40Warning: django.utils.translation.ugettext_lazy() is deprecated in favor of django.utils.translation.gettext_lazy().
  status = StatusField(_('status'))
/home/martin/wks/redacted/venv3/lib/python3.6/site-packages/model_utils/models.py:58: RemovedInDjango40Warning: django.utils.translation.ugettext_lazy() is deprecated in favor of django.utils.translation.gettext_lazy().`

## Solution

Switched from ugettext_lazy to gettext_lazy fixes it.

## Commandments

- [Y] Write PEP8 compliant code.
- [n/a] Cover it with tests.
- [Y] Update `CHANGES.rst` file to describe the changes, and quote according issue with `GH-<issue_number>`.
- [Y] Pay attention to backward compatibility, or if it breaks it, explain why.
- [n/a] Update documentation (if relevant).
