### PR TITLE
Document Django 3.0 enumeration types by 'Choices'

### DIFF
--- a/docs/utilities.rst
+++ b/docs/utilities.rst
@@ -4,8 +4,13 @@ Miscellaneous Utilities
 
 .. _Choices:
 
-Choices
-=======
+``Choices``
+===========
+
+.. note::
+
+    Django 3.0 adds `enumeration types <https://docs.djangoproject.com/en/3.0/releases/3.0/#enumerations-for-model-field-choices>`__.
+    These provide most of the same features as ``Choices``.
 
 ``Choices`` provides some conveniences for setting ``choices`` on a Django model field:
 


### PR DESCRIPTION
Adding docs so others can discover enumeration types. Could also consider deprecating, at least when minimum supported Django is 3.0.
