### PR TITLE
Fix tox django factors

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -5,8 +5,8 @@ envlist =
 
 [testenv]
 deps =
-    django202: Django==2.2.*
-    django201: Django==2.1.*
+    django22: Django==2.2.*
+    django21: Django==2.1.*
     django30: Django==3.0.*
     djangotrunk: https://github.com/django/django/archive/master.tar.gz
     freezegun == 0.3.12


### PR DESCRIPTION
## Problem

The tox `deps` configuration refers to `django20x`, but the `envlist` uses `django2x`.

## Solution

I fixed the discrepancy.  I haven't tested it locally, because I'm getting `psycopg2.OperationalError: could not connect to server`.
