### PR TITLE
removed model from DeferredAttributeTracker

### DIFF
--- a/model_utils/tracker.py
+++ b/model_utils/tracker.py
@@ -185,7 +185,7 @@ class FieldInstanceTracker:
                 field_tracker = FileDescriptorTracker(field_obj.field)
                 setattr(self.instance.__class__, field, field_tracker)
             else:
-                field_tracker = DeferredAttributeTracker(field, type(self.instance))
+                field_tracker = DeferredAttributeTracker(field)
                 setattr(self.instance.__class__, field, field_tracker)
 
 


### PR DESCRIPTION
## Problem
Django dropped model argument from DeferredAttribute more than 2 years ago
https://github.com/django/django/commit/c86e9b5847bc2853fc6a3fcfbf8daa56786d3210#diff-1e7fc0d7d1b36358e371fab97bd1ddb1L118

Using `.defer` or raw sql with few fields brokes tracker.

## Solution
Removed model argument from DeferredAttributeTracker

## Commandments

- [x] Write PEP8 compliant code.
- [ ] Cover it with tests.
- [ ] Update `CHANGES.rst` file to describe the changes, and quote according issue with `GH-<issue_number>`.
- [x] Pay attention to backward compatibility, or if it breaks it, explain why.
- [ ] Update documentation (if relevant).
