### PR TITLE
#435 Fix instance creation state check

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -49,6 +49,7 @@
 | Lucas Wiman <lucaswiman@counsyl.com>
 | Martey Dodoo <martey@mobolic.com>
 | Matthew Schinckel <matt@schinckel.net>
+| Maxim Zemskov <m.zemskov1@gmail.com>
 | Michael van Tellingen <m.vantellingen@lukkien.com>
 | Mike Bryant <m@ocado.com>
 | Mikhail Silonov <m.silonov@corp.mail.ru>

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,7 @@ CHANGES
 - `FieldTracker` now respects `update_fields` changed in overridden `save()`
   method
 - Replace ugettext_lazy with gettext_lazy to satisfy Django deprecation warning
+- `FieldTracker` now works correct with instance where PK field is not `AutoField` (e.g. `UUIDField`)
 
 4.0.0 (2019-12-11)
 ------------------

--- a/model_utils/tracker.py
+++ b/model_utils/tracker.py
@@ -140,7 +140,7 @@ class FieldInstanceTracker:
         """Returns currently saved value of given field"""
 
         # handle deferred fields that have not yet been loaded from the database
-        if self.instance.pk and field in self.deferred_fields and field not in self.saved_data:
+        if not self.instance._state.adding and field in self.deferred_fields and field not in self.saved_data:
 
             # if the field has not been assigned locally, simply fetch and un-defer the value
             if field not in self.instance.__dict__:

--- a/model_utils/tracker.py
+++ b/model_utils/tracker.py
@@ -101,7 +101,7 @@ class FieldInstanceTracker:
         return getattr(self.instance, self.field_map[field])
 
     def set_saved_fields(self, fields=None):
-        if not self.instance.pk:
+        if self.instance._state.adding:
             self.saved_data = {}
         elif fields is None:
             self.saved_data = self.current()
@@ -271,7 +271,7 @@ class ModelInstanceTracker(FieldInstanceTracker):
 
     def has_changed(self, field):
         """Returns ``True`` if field has changed from currently saved value"""
-        if not self.instance.pk:
+        if self.instance._state.adding:
             return True
         elif field in self.saved_data:
             return self.previous(field) != self.get_field_value(field)
@@ -280,7 +280,7 @@ class ModelInstanceTracker(FieldInstanceTracker):
 
     def changed(self):
         """Returns dict of fields that changed since save (with old values)"""
-        if not self.instance.pk:
+        if self.instance._state.adding:
             return {}
         saved = self.saved_data.items()
         current = self.current()

--- a/tests/models.py
+++ b/tests/models.py
@@ -306,7 +306,7 @@ class TrackedMultiple(models.Model):
 class TrackedFileField(models.Model):
     some_file = models.FileField(upload_to='test_location')
 
-    tracker = FieldTracker()
+    tracker = FieldTracker(fields=['some_file'])
 
 
 class InheritedTracked(Tracked):

--- a/tests/models.py
+++ b/tests/models.py
@@ -306,7 +306,7 @@ class TrackedMultiple(models.Model):
 class TrackedFileField(models.Model):
     some_file = models.FileField(upload_to='test_location')
 
-    tracker = FieldTracker(fields=['some_file'])
+    tracker = FieldTracker()
 
 
 class InheritedTracked(Tracked):

--- a/tests/test_fields/test_field_tracker.py
+++ b/tests/test_fields/test_field_tracker.py
@@ -790,7 +790,7 @@ class ModelTrackerForeignKeyTests(FieldTrackerForeignKeyTests):
     tracked_class = ModelTrackedFK
 
     def test_custom_without_id(self):
-        with self.assertNumQueries(2):
+        with self.assertNumQueries(1):
             self.tracked_class.objects.get()
         self.tracker = self.instance.custom_tracker_without_id
         self.assertChanged()


### PR DESCRIPTION
## Problem

FieldTracker has incorrect behaviour if PK field isn't a `AutoFIeld`. Link to issue https://github.com/jazzband/django-model-utils/issues/435.

## Solution

Django has a [`ModelState`](https://github.com/django/django/blob/b7b7df5fbcf44e6598396905136cab5a19e9faff/django/db/models/base.py#L393) object to determine if objects is in creation state or already exists in db. Replacing `if not self.instance.pk is None` with `if self.instance._state.adding` solve the problem.

## Commandments

- [x] Write PEP8 compliant code.
- [ ] Cover it with tests.
- [x] Update `CHANGES.rst` file to describe the changes, and quote according issue with `GH-<issue_number>`.
- [x] Pay attention to backward compatibility, or if it breaks it, explain why.
- [ ] Update documentation (if relevant).
