### PR TITLE
Change assert calls to avoid deprecation warnings.

### DIFF
--- a/tests/test_inheritance_iterable.py
+++ b/tests/test_inheritance_iterable.py
@@ -17,4 +17,4 @@ class InheritanceIterableTest(TestCase):
                 to_attr='normal_field_prefetched'
             )
         )
-        self.assertEquals(qs.count(), 0)
+        self.assertEqual(qs.count(), 0)

--- a/tests/test_managers/test_inheritance_manager.py
+++ b/tests/test_managers/test_inheritance_manager.py
@@ -44,7 +44,7 @@ class InheritanceManagerTests(TestCase):
         raise an AttributeError further in.
         """
         regex = '^.+? is not in the discovered subclasses, tried:.+$'
-        with self.assertRaisesRegexp(ValueError, regex):
+        with self.assertRaisesRegex(ValueError, regex):
             self.get_manager().select_subclasses('user')
 
     def test_select_specific_subclasses(self):
@@ -306,7 +306,7 @@ class InheritanceManagerUsingModelsTests(TestCase):
         Confirming that giving a stupid model doesn't work.
         """
         regex = '^.+? is not a subclass of .+$'
-        with self.assertRaisesRegexp(ValueError, regex):
+        with self.assertRaisesRegex(ValueError, regex):
             InheritanceManagerTestParent.objects.select_subclasses(
                 TimeFrame).order_by('pk')
 

--- a/tests/test_managers/test_join_manager.py
+++ b/tests/test_managers/test_join_manager.py
@@ -17,21 +17,21 @@ class JoinManagerTest(TestCase):
         a_slice = BoxJoinModel.objects.all()[0:10]
         with self.assertNumQueries(1):
             result = a_slice.join()
-        self.assertEquals(result.count(), 10)
+        self.assertEqual(result.count(), 10)
 
     def test_self_join_with_where_statement(self):
         qs = BoxJoinModel.objects.filter(name='name_1')
         result = qs.join()
-        self.assertEquals(result.count(), 1)
+        self.assertEqual(result.count(), 1)
 
     def test_join_with_other_qs(self):
         item_qs = JoinItemForeignKey.objects.filter(weight=10)
         boxes = BoxJoinModel.objects.all().join(qs=item_qs)
-        self.assertEquals(boxes.count(), 1)
-        self.assertEquals(boxes[0].name, 'name_1')
+        self.assertEqual(boxes.count(), 1)
+        self.assertEqual(boxes[0].name, 'name_1')
 
     def test_reverse_join(self):
         box_qs = BoxJoinModel.objects.filter(name='name_1')
         items = JoinItemForeignKey.objects.all().join(box_qs)
-        self.assertEquals(items.count(), 1)
-        self.assertEquals(items[0].weight, 10)
+        self.assertEqual(items.count(), 1)
+        self.assertEqual(items[0].weight, 10)


### PR DESCRIPTION
## Problem

Running the tests emits a number of deprecation warnings like this:

```
tests/test_managers/test_join_manager.py::JoinManagerTest::test_reverse_join
  /Users/craiga/django-model-utils/tests/test_managers/test_join_manager.py:36: DeprecationWarning: Please use assertEqual instead.
    self.assertEquals(items.count(), 1)
```

## Solution

Rename methods as described in error message :)

## Commandments

- [x] Write PEP8 compliant code.
- [x] Cover it with tests.
- [ ] Update `CHANGES.rst` file to describe the changes, and quote according issue with `GH-<issue_number>`.
- [ ] Pay attention to backward compatibility, or if it breaks it, explain why.
- [x] Update documentation (if relevant).
