### PR TITLE
Add support for Django 3.1

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,7 @@ CHANGES
 - Replace ugettext_lazy with gettext_lazy to satisfy Django deprecation warning
 - Add available_objects manager to SoftDeletableModel and add deprecation
   warning to objects manager.
+- Add support for `Django 3.1`
 
 4.0.0 (2019-12-11)
 ------------------

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,7 @@ setup(
         'Framework :: Django :: 2.1',
         'Framework :: Django :: 2.2',
         'Framework :: Django :: 3.0',
+        'Framework :: Django :: 3.1',
     ],
     zip_safe=False,
     tests_require=['Django>=2.1'],

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{36,37,38}-django{21,22,30,trunk}
+    py{36,37,38}-django{21,22,30,31,trunk}
     flake8
 
 [testenv]
@@ -8,6 +8,7 @@ deps =
     django22: Django==2.2.*
     django21: Django==2.1.*
     django30: Django==3.0.*
+    django31: Django==3.1.*
     djangotrunk: https://github.com/django/django/archive/master.tar.gz
     freezegun == 0.3.12
     -rrequirements-test.txt


### PR DESCRIPTION
## Problem

Add support for Django 3.1

## Commandments

- [ ] Write PEP8 compliant code.
- [ ] Cover it with tests.
- [ ] Update `CHANGES.rst` file to describe the changes, and quote according issue with `GH-<issue_number>`.
- [ ] Pay attention to backward compatibility, or if it breaks it, explain why.
- [ ] Update documentation (if relevant).
