### PR TITLE
Issues with TimeStamped model's 'modified' and 'update_fields'

### DIFF
--- a/model_utils/models.py
+++ b/model_utils/models.py
@@ -34,8 +34,12 @@ class TimeStampedModel(models.Model):
         modified field is updated even if it is not given as
         a parameter to the update field argument.
         """
-        if 'update_fields' in kwargs and 'modified' not in kwargs['update_fields']:
-            kwargs['update_fields'] += ['modified']
+        update_fields = kwargs.get('update_fields', None)
+        if update_fields is not None:
+            update_fields = set(update_fields)
+            if update_fields:
+                kwargs['update_fields'] = update_fields.union({'modified'})
+
         super().save(*args, **kwargs)
 
     class Meta:

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -2,3 +2,4 @@ pytest==6.0.2
 pytest-django==3.10.0
 psycopg2-binary==2.8.6
 pytest-cov==2.10.1
+parameterized==0.7.4

--- a/tests/models.py
+++ b/tests/models.py
@@ -89,7 +89,7 @@ class InheritanceManagerTestChild4(InheritanceManagerTestParent):
 
 
 class TimeStamp(TimeStampedModel):
-    pass
+    test_field = models.PositiveSmallIntegerField(default=0)
 
 
 class TimeFrame(TimeFramedModel):

--- a/tests/test_models/test_timestamped_model.py
+++ b/tests/test_models/test_timestamped_model.py
@@ -127,7 +127,7 @@ class TimeStampedModelTests(TestCase):
     @parameterized.expand([
         ('list', []),
         ('tuple', ()),
-        ('set', {}),
+        ('set', set()),
     ])
     def test_save_is_skipped_for_empty_update_fields_iterable(self, _, update_fields):
         with freeze_time(datetime(2020, 1, 1)):

--- a/tox.ini
+++ b/tox.ini
@@ -5,13 +5,13 @@ envlist =
 
 [testenv]
 deps =
+    freezegun==0.3.12
+    -rrequirements-test.txt
     django22: Django==2.2.*
     django21: Django==2.1.*
     django30: Django==3.0.*
     django31: Django==3.1.*
     djangotrunk: https://github.com/django/django/archive/master.tar.gz
-    freezegun == 0.3.12
-    -rrequirements-test.txt
 ignore_outcome =
     djangotrunk: True
 passenv =


### PR DESCRIPTION
## Problem

There are a few issues with current implementation of `TimeStamped.save()` method related to how it handles the `update_fields` argument.
Here's how current implementation diverges from [Django docs](https://docs.djangoproject.com/en/3.1/ref/models/instances/#specifying-which-fields-to-save):
1. It expects `update_fields` to be a `list`, while it can be any iterable:
> The update_fields argument can be any iterable containing strings.
2. When passed an empty list, it will add `modified` to it thus triggering an unexpected save:
> An empty update_fields iterable will skip the save.
3. Explicitly passing `update_fields=None` causes `TypeError`, while it's a valid value:
> A value of None will perform an update on all fields.

## Solution

This PR adds a few checks to `TimeStamped.save` method to ensure that:
1. Any iterable is supported - by converting `update_fields` it to a `set` before trying to add the `'modified'` field to it. `set` is chosen so that we can avoid explicit `'modified' in updated_fields` check and rely on uniqueness of its elements instead;
2. `'modified'` not added to an empty `updated_fields`;
3. `None` value passed to the `super` method as it is.

## Commandments

- [x] Write PEP8 compliant code.
- [x] Cover it with tests.
- [ ] Update `CHANGES.rst` file to describe the changes, and quote according issue with `GH-<issue_number>`.
- [x] Pay attention to backward compatibility, or if it breaks it, explain why.
- [ ] Update documentation (if relevant).
