### PR TITLE
Replace ugettext_lazy with gettext_lazy in test models to satisfy Django deprecation warning.

### DIFF
--- a/tests/models.py
+++ b/tests/models.py
@@ -2,7 +2,7 @@ import django
 from django.db import models
 from django.db.models.query_utils import DeferredAttribute
 from django.db.models import Manager
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from model_utils import Choices
 from model_utils.fields import (


### PR DESCRIPTION
## Problem

Related to https://github.com/jazzband/django-model-utils/commit/6fba04ec4ff32b34cca61c6f1770ef6e81a40e2b.

## Solution

Explain the solution that has been implemented, and what has been changed.

## Commandments

- [ ] Write PEP8 compliant code.
- [ ] Cover it with tests.
- [ ] Update `CHANGES.rst` file to describe the changes, and quote according issue with `GH-<issue_number>`.
- [ ] Pay attention to backward compatibility, or if it breaks it, explain why.
- [ ] Update documentation (if relevant).
