### PR TITLE
Remove codes related to old versions of Django.

### DIFF
--- a/model_utils/managers.py
+++ b/model_utils/managers.py
@@ -1,6 +1,5 @@
 import warnings
 
-import django
 from django.core.exceptions import ObjectDoesNotExist
 from django.db import connection
 from django.db import models
@@ -96,18 +95,11 @@ class InheritanceQuerySetMixin:
         return super()._chain(**kwargs)
 
     def _clone(self, klass=None, setup=False, **kwargs):
-        if django.VERSION >= (2, 0):
-            qs = super()._clone()
-            for name in ['subclasses', '_annotated']:
-                if hasattr(self, name):
-                    setattr(qs, name, getattr(self, name))
-            return qs
-
+        qs = super()._clone()
         for name in ['subclasses', '_annotated']:
             if hasattr(self, name):
-                kwargs[name] = getattr(self, name)
-
-        return super()._clone(**kwargs)
+                setattr(qs, name, getattr(self, name))
+        return qs
 
     def annotate(self, *args, **kwargs):
         qset = super().annotate(*args, **kwargs)

--- a/tests/test_inheritance_iterable.py
+++ b/tests/test_inheritance_iterable.py
@@ -1,6 +1,3 @@
-from unittest import skipIf
-
-import django
 from django.test import TestCase
 from django.db.models import Prefetch
 
@@ -8,7 +5,6 @@ from tests.models import InheritanceManagerTestParent, InheritanceManagerTestChi
 
 
 class InheritanceIterableTest(TestCase):
-    @skipIf(django.VERSION[:2] == (1, 10), "Django 1.10 expects ModelIterable not a subclass of it")
     def test_prefetch(self):
         qs = InheritanceManagerTestChild1.objects.all().prefetch_related(
             Prefetch(


### PR DESCRIPTION
## Problem

Since we don't support Django < 2.2 we can remove parts of code that handle them.

## Solution

Explain the solution that has been implemented, and what has been changed.

## Commandments

- [ ] Write PEP8 compliant code.
- [ ] Cover it with tests.
- [ ] Update `CHANGES.rst` file to describe the changes, and quote according issue with `GH-<issue_number>`.
- [ ] Pay attention to backward compatibility, or if it breaks it, explain why.
- [ ] Update documentation (if relevant).
