### PR TITLE
Removed universal wheel builds

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -6,6 +6,3 @@ all_files = 1
 [tool:pytest]
 django_find_project = false
 DJANGO_SETTINGS_MODULE = tests.settings
-
-[wheel]
-universal = 1


### PR DESCRIPTION
No longer required as Python 2 support is deprecated

## Problem

Explain the problem you are fixing (add the link to the related issue(s), if any).

## Solution

Explain the solution that has been implemented, and what has been changed.

## Commandments

- [ ] Write PEP8 compliant code.
- [ ] Cover it with tests.
- [ ] Update `CHANGES.rst` file to describe the changes, and quote according issue with `GH-<issue_number>`.
- [ ] Pay attention to backward compatibility, or if it breaks it, explain why.
- [ ] Update documentation (if relevant).
