### PR TITLE
Improve tests

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -2,4 +2,3 @@ pytest==6.0.2
 pytest-django==3.10.0
 psycopg2-binary==2.8.6
 pytest-cov==2.10.1
-parameterized==0.7.4

--- a/tests/test_models/test_timestamped_model.py
+++ b/tests/test_models/test_timestamped_model.py
@@ -111,20 +111,6 @@ class TimeStampedModelTests(TestCase):
         self.assertEqual(t1.modified, datetime(2020, 1, 2))
 
     @parameterized.expand([
-        ('list', ['test_field']),
-        ('tuple', ('test_field',)),
-        ('set', {'test_field'}),
-    ])
-    def test_save_with_update_fields_updates_modified_even_when_it_is_not_included_in_a(self, _, update_fields):
-        with freeze_time(datetime(2020, 1, 1)):
-            t1 = TimeStamp.objects.create()
-
-        with freeze_time(datetime(2020, 1, 2)):
-            t1.save(update_fields=update_fields)
-
-        self.assertEqual(t1.modified, datetime(2020, 1, 2))
-
-    @parameterized.expand([
         ('list', []),
         ('tuple', ()),
         ('set', set()),

--- a/tests/test_models/test_timestamped_model.py
+++ b/tests/test_models/test_timestamped_model.py
@@ -2,7 +2,6 @@ from datetime import datetime, timedelta
 
 from django.test import TestCase
 from freezegun import freeze_time
-from parameterized import parameterized
 
 from tests.models import TimeStamp, TimeStampWithStatusModel
 
@@ -91,41 +90,46 @@ class TimeStampedModelTests(TestCase):
         self.assertNotEqual(t1.modified, different_date2)
         self.assertNotEqual(t1.modified, different_date)
 
-    @parameterized.expand([
-        ('list', ['modified']),
-        ('tuple', ('modified',)),
-        ('set', {'modified'}),
-    ])
-    def test_save_with_update_fields_overrides_modified_provided_within_a(self, _, update_fields):
+    def test_save_with_update_fields_overrides_modified_provided_within_a(self):
         """
         Tests if the save method updated modified field
         accordingly when update_fields is used as an argument
         and modified is provided
         """
-        with freeze_time(datetime(2020, 1, 1)):
-            t1 = TimeStamp.objects.create()
+        tests = (
+            ['modified'],  # list
+            ('modified',),  # tuple
+            {'modified'},  # set
+        )
 
-        with freeze_time(datetime(2020, 1, 2)):
-            t1.save(update_fields=update_fields)
+        for update_fields in tests:
+            with self.subTest(update_fields=update_fields):
+                with freeze_time(datetime(2020, 1, 1)):
+                    t1 = TimeStamp.objects.create()
 
-        self.assertEqual(t1.modified, datetime(2020, 1, 2))
+                with freeze_time(datetime(2020, 1, 2)):
+                    t1.save(update_fields=update_fields)
+                self.assertEqual(t1.modified, datetime(2020, 1, 2))
 
-    @parameterized.expand([
-        ('list', []),
-        ('tuple', ()),
-        ('set', set()),
-    ])
-    def test_save_is_skipped_for_empty_update_fields_iterable(self, _, update_fields):
-        with freeze_time(datetime(2020, 1, 1)):
-            t1 = TimeStamp.objects.create()
+    def test_save_is_skipped_for_empty_update_fields_iterable(self):
+        tests = (
+            [],  # list
+            (),  # tuple
+            set(),  # set
+        )
 
-        with freeze_time(datetime(2020, 1, 2)):
-            t1.test_field = 1
-            t1.save(update_fields=update_fields)
+        for update_fields in tests:
+            with self.subTest(update_fields=update_fields):
+                with freeze_time(datetime(2020, 1, 1)):
+                    t1 = TimeStamp.objects.create()
 
-        t1.refresh_from_db()
-        self.assertEqual(t1.test_field, 0)
-        self.assertEqual(t1.modified, datetime(2020, 1, 1))
+                with freeze_time(datetime(2020, 1, 2)):
+                    t1.test_field = 1
+                    t1.save(update_fields=update_fields)
+
+                t1.refresh_from_db()
+                self.assertEqual(t1.test_field, 0)
+                self.assertEqual(t1.modified, datetime(2020, 1, 1))
 
     def test_save_updates_modified_value_when_update_fields_explicitly_set_to_none(self):
         with freeze_time(datetime(2020, 1, 1)):


### PR DESCRIPTION
## Problem
Improve tests:
* Remove `test_save_with_update_fields_updates_modified_even_when_it_is_not_included_in_a` because it's duplicate of `test_save_with_update_fields_overrides_modified_provided_within_a`
* Rewrite test by `subTest` and remove `parameterized` test dependancy

## Solution

Explain the solution that has been implemented, and what has been changed.

## Commandments

- [x] Write PEP8 compliant code.
- [x] Cover it with tests.
- [ ] Update `CHANGES.rst` file to describe the changes, and quote according issue with `GH-<issue_number>`.
- [ ] Pay attention to backward compatibility, or if it breaks it, explain why.
- [ ] Update documentation (if relevant).
