### PR TITLE
Remove deprecated model manager.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 CHANGES
 =======
 
+Unreleased
+----------
+
+- SoftDeletableModel no longer uses SoftDeletableManager as its default manager (GH-364)
+
 4.1.1 (2020-12-01)
 ------------------
 - Applied `isort` to codebase (Refs GH-#402)

--- a/docs/models.rst
+++ b/docs/models.rst
@@ -87,9 +87,7 @@ This abstract base class just provides a field ``is_removed`` which is
 set to True instead of removing the instance. Entities returned in
 manager ``available_objects`` are limited to not-deleted instances.
 
-Note that relying on the default ``objects`` manager to filter out not-deleted
-instances is deprecated. ``objects`` will include deleted objects in a future
-release.
+Note that the default manager includes soft-deleted instances.
 
 
 UUIDModel

--- a/model_utils/managers.py
+++ b/model_utils/managers.py
@@ -274,24 +274,10 @@ class SoftDeletableManagerMixin:
     """
     _queryset_class = SoftDeletableQuerySet
 
-    def __init__(self, *args, _emit_deprecation_warnings=False, **kwargs):
-        self.emit_deprecation_warnings = _emit_deprecation_warnings
-        super().__init__(*args, **kwargs)
-
     def get_queryset(self):
         """
         Return queryset limited to not removed entries.
         """
-
-        if self.emit_deprecation_warnings:
-            warning_message = (
-                "{0}.objects model manager will include soft-deleted objects in an "
-                "upcoming release; please use {0}.available_objects to continue "
-                "excluding soft-deleted objects. See "
-                "https://django-model-utils.readthedocs.io/en/stable/models.html"
-                "#softdeletablemodel for more information."
-            ).format(self.model.__class__.__name__)
-            warnings.warn(warning_message, DeprecationWarning)
 
         kwargs = {'model': self.model, 'using': self._db}
         if hasattr(self, '_hints'):

--- a/model_utils/models.py
+++ b/model_utils/models.py
@@ -143,9 +143,8 @@ class SoftDeletableModel(models.Model):
     class Meta:
         abstract = True
 
-    objects = SoftDeletableManager(_emit_deprecation_warnings=True)
-    available_objects = SoftDeletableManager()
     all_objects = models.Manager()
+    available_objects = SoftDeletableManager()
 
     def delete(self, using=None, soft=True, *args, **kwargs):
         """

--- a/tests/models.py
+++ b/tests/models.py
@@ -360,13 +360,7 @@ class StatusFieldChoicesName(models.Model):
 
 
 class SoftDeletable(SoftDeletableModel):
-    """
-    Test model with additional manager for full access to model
-    instances.
-    """
     name = models.CharField(max_length=20)
-
-    all_objects = models.Manager()
 
 
 class CustomSoftDelete(SoftDeletableModel):

--- a/tests/test_models/test_softdeletable_model.py
+++ b/tests/test_models/test_softdeletable_model.py
@@ -46,8 +46,11 @@ class SoftDeletableModelTests(TestCase):
     def test_instance_purge_no_connection(self):
         instance = SoftDeletable.available_objects.create(name='a')
 
-        self.assertRaises(ConnectionDoesNotExist, instance.delete,
-                          using='other', soft=False)
+        self.assertRaises(
+            ConnectionDoesNotExist, instance.delete, using='other', soft=False
+        )
 
-    def test_deprecation_warning(self):
-        self.assertWarns(DeprecationWarning, SoftDeletable.objects.all)
+    def test_default_manager_includes_removed(self):
+        SoftDeletable.available_objects.create(name='a', is_removed=True)
+        self.assertEqual(SoftDeletable.available_objects.count(), 0)
+        self.assertEqual(SoftDeletable._default_manager.count(), 1)


### PR DESCRIPTION
## Problem

Fixes #364 by not using `SoftDeletableManager` as the default manager for `SoftDeletableModel`.

## Solution

Explain the solution that has been implemented, and what has been changed.

## Commandments

- [ ] Write PEP8 compliant code.
- [ ] Cover it with tests.
- [ ] Update `CHANGES.rst` file to describe the changes, and quote according issue with `GH-<issue_number>`.
- [ ] Pay attention to backward compatibility, or if it breaks it, explain why.
- [ ] Update documentation (if relevant).
