### PR TITLE
Add support for Django 3.2 and drop support for Django 3.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,10 @@
 CHANGES
 =======
 
+Unreleased
+----------
+- Add support for `Django 3.2`
+
 4.1.1 (2020-12-01)
 ------------------
 - Applied `isort` to codebase (Refs GH-#402)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ CHANGES
 Unreleased
 ----------
 - Add support for `Django 3.2`
+- Drop support for `Django 3.0`
 
 4.1.1 (2020-12-01)
 ------------------

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,7 @@ setup(
         'Framework :: Django :: 2.2',
         'Framework :: Django :: 3.0',
         'Framework :: Django :: 3.1',
+        'Framework :: Django :: 3.2',
     ],
     zip_safe=False,
     tests_require=['Django>=2.2'],

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,6 @@ setup(
         'Programming Language :: Python :: 3.9',
         'Framework :: Django',
         'Framework :: Django :: 2.2',
-        'Framework :: Django :: 3.0',
         'Framework :: Django :: 3.1',
         'Framework :: Django :: 3.2',
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{36,37,38,39}-dj{22,30,31}
+    py{36,37,38,39}-dj{22,30,31,32}
     py{38,39}-djmain
     flake8
     isort
@@ -19,6 +19,7 @@ deps =
     dj22: Django==2.2.*
     dj30: Django==3.0.*
     dj31: Django==3.1.*
+    dj32: Django==3.2.*
     djmain: https://github.com/django/django/archive/main.tar.gz
 ignore_outcome =
     djmain: True

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{36,37,38,39}-dj{22,30,31,32}
+    py{36,37,38,39}-dj{22,31,32}
     py{38,39}-djmain
     flake8
     isort
@@ -17,7 +17,6 @@ deps =
     freezegun==0.3.12
     -rrequirements-test.txt
     dj22: Django==2.2.*
-    dj30: Django==3.0.*
     dj31: Django==3.1.*
     dj32: Django==3.2.*
     djmain: https://github.com/django/django/archive/main.tar.gz


### PR DESCRIPTION
## Problem

Explain the problem you are fixing (add the link to the related issue(s), if any).

## Solution

Explain the solution that has been implemented, and what has been changed.

## Commandments

- [ ] Write PEP8 compliant code.
- [ ] Cover it with tests.
- [ ] Update `CHANGES.rst` file to describe the changes, and quote according issue with `GH-<issue_number>`.
- [ ] Pay attention to backward compatibility, or if it breaks it, explain why.
- [ ] Update documentation (if relevant).
