### PR TITLE
Fix QuerySet._chain for django main (post-3.2)

### DIFF
--- a/model_utils/managers.py
+++ b/model_utils/managers.py
@@ -86,11 +86,14 @@ class InheritanceQuerySetMixin:
         return new_qs
 
     def _chain(self, **kwargs):
+        update = {}
         for name in ['subclasses', '_annotated']:
             if hasattr(self, name):
-                kwargs[name] = getattr(self, name)
+                update[name] = getattr(self, name)
 
-        return super()._chain(**kwargs)
+        chained = super()._chain(**kwargs)
+        chained.__dict__.update(update)
+        return chained
 
     def _clone(self, klass=None, setup=False, **kwargs):
         qs = super()._clone()


### PR DESCRIPTION
## Problem

Tests are failing agains django main branch (post-3.2) because of `QuerySet._chain` signature change, see https://github.com/django/django/pull/14755/files:

```
# was
def _chain(self, **kwargs): ...

# now
def _chain(self): ...
```

## Solution

Update additional fields manually

## Commandments

- [x] Write PEP8 compliant code.
- [x] Cover it with tests.
- [ ] Update `CHANGES.rst` file to describe the changes, and quote according issue with `GH-<issue_number>`.
- [x] Pay attention to backward compatibility, or if it breaks it, explain why.
- [ ] Update documentation (if relevant).
