### PR TITLE
set deafult DB_host as localhost

### DIFF
--- a/tests/settings.py
+++ b/tests/settings.py
@@ -10,7 +10,7 @@ DATABASES = {
         "NAME": os.environ.get("DB_NAME", "modelutils"),
         "USER": os.environ.get("DB_USER", 'postgres'),
         "PASSWORD": os.environ.get("DB_PASSWORD", ""),
-        "HOST": os.environ.get("DB_HOST", ""),
+        "HOST": os.environ.get("DB_HOST", "localhost"),
         "PORT": os.environ.get("DB_PORT", 5432)
     },
 }


### PR DESCRIPTION
## Problem

Explain the problem you are fixing (add the link to the related issue(s), if any).

When running test and the DB_HOST is not defined, tests would fail.

## Solution

Set the deafult `DB_HOST` to be localhost, since this the usual scinario, specially when running locally.

## Commandments

- [ ] Write PEP8 compliant code.
- [ ] Cover it with tests.
- [ ] Update `CHANGES.rst` file to describe the changes, and quote according issue with `GH-<issue_number>`.
- [ ] Pay attention to backward compatibility, or if it breaks it, explain why.
- [ ] Update documentation (if relevant).
