### PR TITLE
Add initial `.pre-commit.config.yaml`

### DIFF
--- a/pre-commit-config.yaml
+++ b/pre-commit-config.yaml
@@ -1,0 +1,15 @@
+---
+repos:
+  - repo: https://github.com/PyCQA/isort
+    rev: 5.9.3
+    hooks:
+      - id: isort
+        args: ['--profile', 'black', '--check-only', '--diff']
+        files: ^((model_utils|tests)/)|setup.py
+
+  - repo: https://github.com/PyCQA/flake8
+    rev: 4.0.1
+    hooks:
+      - id: flake8
+        args: ['--ignore=E402,E501,E731,W503']
+        files: ^(model_utils|tests)/


### PR DESCRIPTION
## Problem

Someone added the pre-commit.ci check to the repository, but since there is no `.pre-commit.config.yaml` to read the check fails. This means there are a ton of red X's on the PR screen. I hate red X's.

## Solution

This PR introduces a sensible starting `.pre-commit.config.yaml`, with the `isort`, `black`, and `flake8` hooks enabled, plus a few hooks from pre-commit itself.

This PR only includes the config file, it does not include any files changed by running `pre-commit run --all-files`. Doing so would touch 36 files across the project. However, if this PR is merged, it will be run and those 36 files will have to be addressed, otherwise it will just result in more red X's. My stance about red X's has already been covered. Don't like em.

## Commandments

- [ ] Write PEP8 compliant code.
- [ ] Cover it with tests.
- [ ] Update `CHANGES.rst` file to describe the changes, and quote according issue with `GH-<issue_number>`.
- [ ] Pay attention to backward compatibility, or if it breaks it, explain why.
- [ ] Update documentation (if relevant).
