### PR TITLE
Make setuptools dependency optional

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -24,6 +24,7 @@
 | Dmytro Kyrychuck <dmytro.kyrychuck@gmail.com>
 | Donald Stufft <donald.stufft@gmail.com>
 | Douglas Meehan <dmeehan@gmail.com>
+| Edward Peek <edward.peek@crown.com>
 | Emin Bugra Saral <eminbugrasaral@me.com>
 | Eran Rundstein <eranrund@gmail.com>
 | Eugene Kuznetsov <atorich@gmail.com>

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@ Changelog
 Unreleased
 ----------
 
+- Gracefully handle `setuptools` not being installed at runtime (GH-#506)
+
 
 4.2.0 (2021-10-11)
 ------------------

--- a/model_utils/__init__.py
+++ b/model_utils/__init__.py
@@ -1,10 +1,12 @@
-from pkg_resources import DistributionNotFound, get_distribution
-
 from .choices import Choices  # noqa:F401
 from .tracker import FieldTracker, ModelTracker  # noqa:F401
 
 try:
+    from pkg_resources import DistributionNotFound, get_distribution
     __version__ = get_distribution("django-model-utils").version
+except ImportError:  # pragma: no cover
+    # setuptools/pkg-resources is not installed
+    __version__ = None
 except DistributionNotFound:  # pragma: no cover
     # package is not installed
     __version__ = None


### PR DESCRIPTION
Fallback assignment of `model_utils.__version__ = None` if `pkg_resources` can not be imported due to `setuptools` not being installed

## Problem

Fixes https://github.com/jazzband/django-model-utils/issues/506

## Solution

Wrap `pkg_resource` import in a try block as done in other projects like `pytz` to make dependency optional.

## Commandments

- [ ] Write PEP8 compliant code.
- [ ] Cover it with tests.
- [ ] Update `CHANGES.rst` file to describe the changes, and quote according issue with `GH-<issue_number>`.
- [ ] Pay attention to backward compatibility, or if it breaks it, explain why.
- [ ] Update documentation (if relevant).
