### PR TITLE
Switch from freezegun to time-machine.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@
 
 tox
 sphinx
+time-machine
 twine
-freezegun

--- a/tests/test_fields/test_monitor_field.py
+++ b/tests/test_fields/test_monitor_field.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 
 import time_machine
 from django.test import TestCase
@@ -9,7 +9,7 @@ from tests.models import DoubleMonitored, Monitored, MonitorWhen, MonitorWhenEmp
 
 class MonitorFieldTests(TestCase):
     def setUp(self):
-        with time_machine.travel(datetime(2016, 1, 1, 10, 0, 0)):
+        with time_machine.travel(datetime(2016, 1, 1, 10, 0, 0, tzinfo=timezone.utc)):
             self.instance = Monitored(name='Charlie')
             self.created = self.instance.name_changed
 
@@ -18,10 +18,10 @@ class MonitorFieldTests(TestCase):
         self.assertEqual(self.instance.name_changed, self.created)
 
     def test_save_changed(self):
-        with time_machine.travel(datetime(2016, 1, 1, 12, 0, 0)):
+        with time_machine.travel(datetime(2016, 1, 1, 12, 0, 0, tzinfo=timezone.utc)):
             self.instance.name = 'Maria'
             self.instance.save()
-        self.assertEqual(self.instance.name_changed, datetime(2016, 1, 1, 12, 0, 0))
+        self.assertEqual(self.instance.name_changed, datetime(2016, 1, 1, 12, 0, 0, tzinfo=timezone.utc))
 
     def test_double_save(self):
         self.instance.name = 'Jose'
@@ -40,7 +40,7 @@ class MonitorWhenFieldTests(TestCase):
     Will record changes only when name is 'Jose' or 'Maria'
     """
     def setUp(self):
-        with time_machine.travel(datetime(2016, 1, 1, 10, 0, 0)):
+        with time_machine.travel(datetime(2016, 1, 1, 10, 0, 0, tzinfo=timezone.utc)):
             self.instance = MonitorWhen(name='Charlie')
             self.created = self.instance.name_changed
 
@@ -49,16 +49,16 @@ class MonitorWhenFieldTests(TestCase):
         self.assertEqual(self.instance.name_changed, self.created)
 
     def test_save_changed_to_Jose(self):
-        with time_machine.travel(datetime(2016, 1, 1, 12, 0, 0)):
+        with time_machine.travel(datetime(2016, 1, 1, 12, 0, 0, tzinfo=timezone.utc)):
             self.instance.name = 'Jose'
             self.instance.save()
-        self.assertEqual(self.instance.name_changed, datetime(2016, 1, 1, 12, 0, 0))
+        self.assertEqual(self.instance.name_changed, datetime(2016, 1, 1, 12, 0, 0, tzinfo=timezone.utc))
 
     def test_save_changed_to_Maria(self):
-        with time_machine.travel(datetime(2016, 1, 1, 12, 0, 0)):
+        with time_machine.travel(datetime(2016, 1, 1, 12, 0, 0, tzinfo=timezone.utc)):
             self.instance.name = 'Maria'
             self.instance.save()
-        self.assertEqual(self.instance.name_changed, datetime(2016, 1, 1, 12, 0, 0))
+        self.assertEqual(self.instance.name_changed, datetime(2016, 1, 1, 12, 0, 0, tzinfo=timezone.utc))
 
     def test_save_changed_to_Pedro(self):
         self.instance.name = 'Pedro'
@@ -111,7 +111,7 @@ class MonitorDoubleFieldTests(TestCase):
 
     def test_monitor_still_works_with_deferred_fields_filtered_out_of_save_initial(self):
         obj = DoubleMonitored.objects.defer('name').get(name='Charlie')
-        with time_machine.travel("2016-12-01"):
+        with time_machine.travel(datetime(2016, 12, 1, tzinfo=timezone.utc)):
             obj.name = 'Charlie2'
             obj.save()
-        self.assertEqual(obj.name_changed, datetime(2016, 12, 1))
+        self.assertEqual(obj.name_changed, datetime(2016, 12, 1, tzinfo=timezone.utc))

--- a/tests/test_fields/test_monitor_field.py
+++ b/tests/test_fields/test_monitor_field.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 
+import time_machine
 from django.test import TestCase
-from freezegun import freeze_time
 
 from model_utils.fields import MonitorField
 from tests.models import DoubleMonitored, Monitored, MonitorWhen, MonitorWhenEmpty
@@ -9,7 +9,7 @@ from tests.models import DoubleMonitored, Monitored, MonitorWhen, MonitorWhenEmp
 
 class MonitorFieldTests(TestCase):
     def setUp(self):
-        with freeze_time(datetime(2016, 1, 1, 10, 0, 0)):
+        with time_machine.travel(datetime(2016, 1, 1, 10, 0, 0)):
             self.instance = Monitored(name='Charlie')
             self.created = self.instance.name_changed
 
@@ -18,7 +18,7 @@ class MonitorFieldTests(TestCase):
         self.assertEqual(self.instance.name_changed, self.created)
 
     def test_save_changed(self):
-        with freeze_time(datetime(2016, 1, 1, 12, 0, 0)):
+        with time_machine.travel(datetime(2016, 1, 1, 12, 0, 0)):
             self.instance.name = 'Maria'
             self.instance.save()
         self.assertEqual(self.instance.name_changed, datetime(2016, 1, 1, 12, 0, 0))
@@ -40,7 +40,7 @@ class MonitorWhenFieldTests(TestCase):
     Will record changes only when name is 'Jose' or 'Maria'
     """
     def setUp(self):
-        with freeze_time(datetime(2016, 1, 1, 10, 0, 0)):
+        with time_machine.travel(datetime(2016, 1, 1, 10, 0, 0)):
             self.instance = MonitorWhen(name='Charlie')
             self.created = self.instance.name_changed
 
@@ -49,13 +49,13 @@ class MonitorWhenFieldTests(TestCase):
         self.assertEqual(self.instance.name_changed, self.created)
 
     def test_save_changed_to_Jose(self):
-        with freeze_time(datetime(2016, 1, 1, 12, 0, 0)):
+        with time_machine.travel(datetime(2016, 1, 1, 12, 0, 0)):
             self.instance.name = 'Jose'
             self.instance.save()
         self.assertEqual(self.instance.name_changed, datetime(2016, 1, 1, 12, 0, 0))
 
     def test_save_changed_to_Maria(self):
-        with freeze_time(datetime(2016, 1, 1, 12, 0, 0)):
+        with time_machine.travel(datetime(2016, 1, 1, 12, 0, 0)):
             self.instance.name = 'Maria'
             self.instance.save()
         self.assertEqual(self.instance.name_changed, datetime(2016, 1, 1, 12, 0, 0))
@@ -111,7 +111,7 @@ class MonitorDoubleFieldTests(TestCase):
 
     def test_monitor_still_works_with_deferred_fields_filtered_out_of_save_initial(self):
         obj = DoubleMonitored.objects.defer('name').get(name='Charlie')
-        with freeze_time("2016-12-01"):
+        with time_machine.travel("2016-12-01"):
             obj.name = 'Charlie2'
             obj.save()
         self.assertEqual(obj.name_changed, datetime(2016, 12, 1))

--- a/tests/test_models/test_status_model.py
+++ b/tests/test_models/test_status_model.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 
 import time_machine
 from django.test.testcases import TestCase
@@ -43,14 +43,14 @@ class StatusModelTests(TestCase):
         accordingly when update_fields is used as an argument
         and status_changed is provided
         '''
-        with time_machine.travel(datetime(2020, 1, 1)):
+        with time_machine.travel(datetime(2020, 1, 1, tzinfo=timezone.utc)):
             t1 = Status.objects.create()
 
-        with time_machine.travel(datetime(2020, 1, 2)):
+        with time_machine.travel(datetime(2020, 1, 2, tzinfo=timezone.utc)):
             t1.status = Status.on_hold
             t1.save(update_fields=['status', 'status_changed'])
 
-        self.assertEqual(t1.status_changed, datetime(2020, 1, 2))
+        self.assertEqual(t1.status_changed, datetime(2020, 1, 2, tzinfo=timezone.utc))
 
     def test_save_with_update_fields_overrides_status_changed_not_provided(self):
         '''
@@ -58,14 +58,14 @@ class StatusModelTests(TestCase):
         accordingly when update_fields is used as an argument
         with status and status_changed is not provided
         '''
-        with time_machine.travel(datetime(2020, 1, 1)):
+        with time_machine.travel(datetime(2020, 1, 1, tzinfo=timezone.utc)):
             t1 = Status.objects.create()
 
-        with time_machine.travel(datetime(2020, 1, 2)):
+        with time_machine.travel(datetime(2020, 1, 2, tzinfo=timezone.utc)):
             t1.status = Status.on_hold
             t1.save(update_fields=['status'])
 
-        self.assertEqual(t1.status_changed, datetime(2020, 1, 2))
+        self.assertEqual(t1.status_changed, datetime(2020, 1, 2, tzinfo=timezone.utc))
 
 
 class StatusModelPlainTupleTests(StatusModelTests):

--- a/tests/test_models/test_status_model.py
+++ b/tests/test_models/test_status_model.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 
+import time_machine
 from django.test.testcases import TestCase
-from freezegun import freeze_time
 
 from tests.models import Status, StatusCustomManager, StatusPlainTuple
 
@@ -13,7 +13,7 @@ class StatusModelTests(TestCase):
         self.active = Status.STATUS.active
 
     def test_created(self):
-        with freeze_time(datetime(2016, 1, 1)):
+        with time_machine.travel(datetime(2016, 1, 1)):
             c1 = self.model.objects.create()
         self.assertTrue(c1.status_changed, datetime(2016, 1, 1))
 
@@ -43,10 +43,10 @@ class StatusModelTests(TestCase):
         accordingly when update_fields is used as an argument
         and status_changed is provided
         '''
-        with freeze_time(datetime(2020, 1, 1)):
+        with time_machine.travel(datetime(2020, 1, 1)):
             t1 = Status.objects.create()
 
-        with freeze_time(datetime(2020, 1, 2)):
+        with time_machine.travel(datetime(2020, 1, 2)):
             t1.status = Status.on_hold
             t1.save(update_fields=['status', 'status_changed'])
 
@@ -58,10 +58,10 @@ class StatusModelTests(TestCase):
         accordingly when update_fields is used as an argument
         with status and status_changed is not provided
         '''
-        with freeze_time(datetime(2020, 1, 1)):
+        with time_machine.travel(datetime(2020, 1, 1)):
             t1 = Status.objects.create()
 
-        with freeze_time(datetime(2020, 1, 2)):
+        with time_machine.travel(datetime(2020, 1, 2)):
             t1.status = Status.on_hold
             t1.save(update_fields=['status'])
 

--- a/tests/test_models/test_timestamped_model.py
+++ b/tests/test_models/test_timestamped_model.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 import time_machine
 from django.test import TestCase
@@ -8,9 +8,9 @@ from tests.models import TimeStamp, TimeStampWithStatusModel
 
 class TimeStampedModelTests(TestCase):
     def test_created(self):
-        with time_machine.travel(datetime(2016, 1, 1)):
+        with time_machine.travel(datetime(2016, 1, 1, tzinfo=timezone.utc)):
             t1 = TimeStamp.objects.create()
-        self.assertEqual(t1.created, datetime(2016, 1, 1))
+        self.assertEqual(t1.created, datetime(2016, 1, 1, tzinfo=timezone.utc))
 
     def test_created_sets_modified(self):
         '''
@@ -20,13 +20,13 @@ class TimeStampedModelTests(TestCase):
         self.assertEqual(t1.created, t1.modified)
 
     def test_modified(self):
-        with time_machine.travel(datetime(2016, 1, 1)):
+        with time_machine.travel(datetime(2016, 1, 1, tzinfo=timezone.utc)):
             t1 = TimeStamp.objects.create()
 
-        with time_machine.travel(datetime(2016, 1, 2)):
+        with time_machine.travel(datetime(2016, 1, 2, tzinfo=timezone.utc)):
             t1.save()
 
-        self.assertEqual(t1.modified, datetime(2016, 1, 2))
+        self.assertEqual(t1.modified, datetime(2016, 1, 2, tzinfo=timezone.utc))
 
     def test_overriding_created_via_object_creation_also_uses_creation_date_for_modified(self):
         """
@@ -104,12 +104,12 @@ class TimeStampedModelTests(TestCase):
 
         for update_fields in tests:
             with self.subTest(update_fields=update_fields):
-                with time_machine.travel(datetime(2020, 1, 1)):
+                with time_machine.travel(datetime(2020, 1, 1, tzinfo=timezone.utc)):
                     t1 = TimeStamp.objects.create()
 
-                with time_machine.travel(datetime(2020, 1, 2)):
+                with time_machine.travel(datetime(2020, 1, 2, tzinfo=timezone.utc)):
                     t1.save(update_fields=update_fields)
-                self.assertEqual(t1.modified, datetime(2020, 1, 2))
+                self.assertEqual(t1.modified, datetime(2020, 1, 2, tzinfo=timezone.utc))
 
     def test_save_is_skipped_for_empty_update_fields_iterable(self):
         tests = (
@@ -120,31 +120,31 @@ class TimeStampedModelTests(TestCase):
 
         for update_fields in tests:
             with self.subTest(update_fields=update_fields):
-                with time_machine.travel(datetime(2020, 1, 1)):
+                with time_machine.travel(datetime(2020, 1, 1, tzinfo=timezone.utc)):
                     t1 = TimeStamp.objects.create()
 
-                with time_machine.travel(datetime(2020, 1, 2)):
+                with time_machine.travel(datetime(2020, 1, 2, tzinfo=timezone.utc)):
                     t1.test_field = 1
                     t1.save(update_fields=update_fields)
 
                 t1.refresh_from_db()
                 self.assertEqual(t1.test_field, 0)
-                self.assertEqual(t1.modified, datetime(2020, 1, 1))
+                self.assertEqual(t1.modified, datetime(2020, 1, 1, tzinfo=timezone.utc))
 
     def test_save_updates_modified_value_when_update_fields_explicitly_set_to_none(self):
-        with time_machine.travel(datetime(2020, 1, 1)):
+        with time_machine.travel(datetime(2020, 1, 1, tzinfo=timezone.utc)):
             t1 = TimeStamp.objects.create()
 
-        with time_machine.travel(datetime(2020, 1, 2)):
+        with time_machine.travel(datetime(2020, 1, 2, tzinfo=timezone.utc)):
             t1.save(update_fields=None)
 
-        self.assertEqual(t1.modified, datetime(2020, 1, 2))
+        self.assertEqual(t1.modified, datetime(2020, 1, 2, tzinfo=timezone.utc))
 
     def test_model_inherit_timestampmodel_and_statusmodel(self):
-        with time_machine.travel(datetime(2020, 1, 1)):
+        with time_machine.travel(datetime(2020, 1, 1, tzinfo=timezone.utc)):
             t1 = TimeStampWithStatusModel.objects.create()
 
-        with time_machine.travel(datetime(2020, 1, 2)):
+        with time_machine.travel(datetime(2020, 1, 2, tzinfo=timezone.utc)):
             t1.save(update_fields=['test_field', 'status'])
 
-        self.assertEqual(t1.modified, datetime(2020, 1, 2))
+        self.assertEqual(t1.modified, datetime(2020, 1, 2, tzinfo=timezone.utc))

--- a/tests/test_models/test_timestamped_model.py
+++ b/tests/test_models/test_timestamped_model.py
@@ -1,14 +1,14 @@
 from datetime import datetime, timedelta
 
+import time_machine
 from django.test import TestCase
-from freezegun import freeze_time
 
 from tests.models import TimeStamp, TimeStampWithStatusModel
 
 
 class TimeStampedModelTests(TestCase):
     def test_created(self):
-        with freeze_time(datetime(2016, 1, 1)):
+        with time_machine.travel(datetime(2016, 1, 1)):
             t1 = TimeStamp.objects.create()
         self.assertEqual(t1.created, datetime(2016, 1, 1))
 
@@ -20,10 +20,10 @@ class TimeStampedModelTests(TestCase):
         self.assertEqual(t1.created, t1.modified)
 
     def test_modified(self):
-        with freeze_time(datetime(2016, 1, 1)):
+        with time_machine.travel(datetime(2016, 1, 1)):
             t1 = TimeStamp.objects.create()
 
-        with freeze_time(datetime(2016, 1, 2)):
+        with time_machine.travel(datetime(2016, 1, 2)):
             t1.save()
 
         self.assertEqual(t1.modified, datetime(2016, 1, 2))
@@ -104,10 +104,10 @@ class TimeStampedModelTests(TestCase):
 
         for update_fields in tests:
             with self.subTest(update_fields=update_fields):
-                with freeze_time(datetime(2020, 1, 1)):
+                with time_machine.travel(datetime(2020, 1, 1)):
                     t1 = TimeStamp.objects.create()
 
-                with freeze_time(datetime(2020, 1, 2)):
+                with time_machine.travel(datetime(2020, 1, 2)):
                     t1.save(update_fields=update_fields)
                 self.assertEqual(t1.modified, datetime(2020, 1, 2))
 
@@ -120,10 +120,10 @@ class TimeStampedModelTests(TestCase):
 
         for update_fields in tests:
             with self.subTest(update_fields=update_fields):
-                with freeze_time(datetime(2020, 1, 1)):
+                with time_machine.travel(datetime(2020, 1, 1)):
                     t1 = TimeStamp.objects.create()
 
-                with freeze_time(datetime(2020, 1, 2)):
+                with time_machine.travel(datetime(2020, 1, 2)):
                     t1.test_field = 1
                     t1.save(update_fields=update_fields)
 
@@ -132,19 +132,19 @@ class TimeStampedModelTests(TestCase):
                 self.assertEqual(t1.modified, datetime(2020, 1, 1))
 
     def test_save_updates_modified_value_when_update_fields_explicitly_set_to_none(self):
-        with freeze_time(datetime(2020, 1, 1)):
+        with time_machine.travel(datetime(2020, 1, 1)):
             t1 = TimeStamp.objects.create()
 
-        with freeze_time(datetime(2020, 1, 2)):
+        with time_machine.travel(datetime(2020, 1, 2)):
             t1.save(update_fields=None)
 
         self.assertEqual(t1.modified, datetime(2020, 1, 2))
 
     def test_model_inherit_timestampmodel_and_statusmodel(self):
-        with freeze_time(datetime(2020, 1, 1)):
+        with time_machine.travel(datetime(2020, 1, 1)):
             t1 = TimeStampWithStatusModel.objects.create()
 
-        with freeze_time(datetime(2020, 1, 2)):
+        with time_machine.travel(datetime(2020, 1, 2)):
             t1.save(update_fields=['test_field', 'status'])
 
         self.assertEqual(t1.modified, datetime(2020, 1, 2))

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ python =
 
 [testenv]
 deps =
-    freezegun==0.3.12
+    time-machine==2.4.1
     -rrequirements-test.txt
     dj22: Django==2.2.*
     dj31: Django==3.1.*


### PR DESCRIPTION
## Problem

freezegun is slow.

## Solution

time-machine is [more accurate](https://adamj.eu/tech/2020/06/03/introducing-time-machine/) and [faster](https://adamj.eu/tech/2021/02/19/freezegun-versus-time-machine/).

## Commandments

- [x] Write PEP8 compliant code.
- [x] Cover it with tests.
- [n/a] Update `CHANGES.rst` file to describe the changes, and quote according issue with `GH-<issue_number>`.
- [n/a] Pay attention to backward compatibility, or if it breaks it, explain why.
- [n/a] Update documentation (if relevant).
