### PR TITLE
Fix name of pre-commit file

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,3 @@
----
 repos:
   - repo: https://github.com/PyCQA/isort
     rev: 5.9.3


### PR DESCRIPTION
## Problem

Without this, it is failing with:

```
An error has occurred: InvalidConfigError:
=====> .pre-commit-config.yaml is not a file
```

... locally, and [on pre-commit.ci](https://results.pre-commit.ci/run/github/367233/1638617692.MJfSfSpAStKRpS_gf4Wieg).

## Solution

Use the expected filename

## Commandments

- [n/a] Write PEP8 compliant code.
- [n/a] Cover it with tests.
- [n/a] Update `CHANGES.rst` file to describe the changes, and quote according issue with `GH-<issue_number>`.
- [n/a] Pay attention to backward compatibility, or if it breaks it, explain why.
- [n/a] Update documentation (if relevant).
