### PR TITLE
Allow running tests using sqlite

### DIFF
--- a/tests/settings.py
+++ b/tests/settings.py
@@ -14,7 +14,7 @@ if os.environ.get('SQLITE'):
 else:
     DATABASES = {
         "default": {
-            "ENGINE": "django.db.backends.postgresql_psycopg2",
+            "ENGINE": "django.db.backends.postgresql",
             "NAME": os.environ.get("DB_NAME", "modelutils"),
             "USER": os.environ.get("DB_USER", 'postgres'),
             "PASSWORD": os.environ.get("DB_PASSWORD", ""),

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -4,16 +4,25 @@ INSTALLED_APPS = (
     'model_utils',
     'tests',
 )
-DATABASES = {
-    "default": {
-        "ENGINE": "django.db.backends.postgresql_psycopg2",
-        "NAME": os.environ.get("DB_NAME", "modelutils"),
-        "USER": os.environ.get("DB_USER", 'postgres'),
-        "PASSWORD": os.environ.get("DB_PASSWORD", ""),
-        "HOST": os.environ.get("DB_HOST", "localhost"),
-        "PORT": os.environ.get("DB_PORT", 5432)
-    },
-}
+
+if os.environ.get('SQLITE'):
+    DATABASES = {
+        'default': {
+            'ENGINE': 'django.db.backends.sqlite3',
+        },
+    }
+else:
+    DATABASES = {
+        "default": {
+            "ENGINE": "django.db.backends.postgresql_psycopg2",
+            "NAME": os.environ.get("DB_NAME", "modelutils"),
+            "USER": os.environ.get("DB_USER", 'postgres'),
+            "PASSWORD": os.environ.get("DB_PASSWORD", ""),
+            "HOST": os.environ.get("DB_HOST", "localhost"),
+            "PORT": os.environ.get("DB_PORT", 5432)
+        },
+    }
+
 SECRET_KEY = 'dummy'
 
 CACHES = {


### PR DESCRIPTION
## Problem

Distro build workers do not want to install postgres in order to run the tests.

## Solution

Added capability to use sqlite instead using env flag `SQLITE`

## Commandments

- [x] Write PEP8 compliant code.
- [ ] Cover it with tests.
- [ ] Update `CHANGES.rst` file to describe the changes, and quote according issue with `GH-<issue_number>`.
- [x] Pay attention to backward compatibility, or if it breaks it, explain why.
- [x] Update documentation (if relevant).
