### PR TITLE
Remove workaround from select_subclasess()

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,7 @@ Unreleased
 - Confirm support for `Django 4.0`
 - Add Spanish translation
 - Add French translation
+- Drop Django 1.7 workaround from `select_subclasses()`
 
 4.2.0 (2021-10-11)
 ------------------

--- a/model_utils/managers.py
+++ b/model_utils/managers.py
@@ -72,16 +72,10 @@ class InheritanceQuerySetMixin:
                     )
             subclasses = verified_subclasses
 
-        # workaround https://code.djangoproject.com/ticket/16855
-        previous_select_related = self.query.select_related
         if subclasses:
             new_qs = self.select_related(*subclasses)
         else:
             new_qs = self
-        previous_is_dict = isinstance(previous_select_related, dict)
-        new_is_dict = isinstance(new_qs.query.select_related, dict)
-        if previous_is_dict and new_is_dict:
-            new_qs.query.select_related.update(previous_select_related)
         new_qs.subclasses = subclasses
         return new_qs
 


### PR DESCRIPTION
## Problem

The workaround was for an issue that was fixed in Django 1.7: https://code.djangoproject.com/ticket/16855 / https://github.com/django/django/commit/349c12d3f5c015c2f8b36917da21230c2ac1acb4 .

## Solution

Remove workaround.

## Commandments

- [x] Write PEP8 compliant code.
- [x] Cover it with tests.
- [x] Update `CHANGES.rst` file to describe the changes, and quote according issue with `GH-<issue_number>`.
- [x] Pay attention to backward compatibility, or if it breaks it, explain why.
- [x] Update documentation (if relevant).
