### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/managers.rst
+++ b/docs/managers.rst
@@ -6,7 +6,7 @@ InheritanceManager
 
 This manager (`contributed by Jeff Elmore`_) should be attached to a base model
 class in a model-inheritance tree.  It allows queries on that base model to
-return heterogenous results of the actual proper subtypes, without any
+return heterogeneous results of the actual proper subtypes, without any
 additional queries.
 
 For instance, if you have a ``Place`` model with subclasses ``Restaurant`` and

--- a/model_utils/managers.py
+++ b/model_utils/managers.py
@@ -185,7 +185,7 @@ class InheritanceQuerySet(InheritanceQuerySetMixin, QuerySet):
         """
         Fetch only objects that are instances of the provided model(s).
         """
-        # If we aren't already selecting the subclasess, we need
+        # If we aren't already selecting the subclasses, we need
         # to in order to get this to work.
 
         # How can we tell if we are not selecting subclasses?
@@ -331,7 +331,7 @@ class JoinQueryset(models.QuerySet):
         to itself.
 
         `Join` either uses the current queryset and effectively does a self-join to
-        create a new limited queryset OR it uses a querset given by the user.
+        create a new limited queryset OR it uses a queryset given by the user.
 
         The model of a given queryset needs to contain a valid foreign key to
         the current queryset to perform a join. A new queryset is then created.

--- a/tests/test_models/test_timestamped_model.py
+++ b/tests/test_models/test_timestamped_model.py
@@ -14,7 +14,7 @@ class TimeStampedModelTests(TestCase):
 
     def test_created_sets_modified(self):
         '''
-        Ensure that on creation that modifed is set exactly equal to created.
+        Ensure that on creation that modified is set exactly equal to created.
         '''
         t1 = TimeStamp.objects.create()
         self.assertEqual(t1.created, t1.modified)
@@ -31,7 +31,7 @@ class TimeStampedModelTests(TestCase):
     def test_overriding_created_via_object_creation_also_uses_creation_date_for_modified(self):
         """
         Setting the created date when first creating an object
-        should be permissable.
+        should be permissible.
         """
         different_date = datetime.today() - timedelta(weeks=52)
         t1 = TimeStamp.objects.create(created=different_date)


### PR DESCRIPTION
There are small typos in:
- docs/managers.rst
- model_utils/managers.py
- tests/test_models/test_timestamped_model.py

Fixes:
- Should read `subclasses` rather than `subclasess`.
- Should read `queryset` rather than `querset`.
- Should read `permissible` rather than `permissable`.
- Should read `modified` rather than `modifed`.
- Should read `heterogeneous` rather than `heterogenous`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md