### PR TITLE
Release 4.3.1.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,8 +1,8 @@
 Changelog
 =========
 
-4.3.0 (2022-11-15)
-----------
+4.3.1 (2022-11-15)
+------------------
 
 - Confirm support for `Django 4.0`
 - Add Spanish translation
@@ -11,6 +11,11 @@ Changelog
 - Drop support for `Django < 3.2`
 - Drop support for `Python 3.6`
 - Confirm support for `Django 4.1`
+
+4.3.0
+-----
+
+- Never released due to packaging issues.
 
 4.2.0 (2021-10-11)
 ------------------


### PR DESCRIPTION
This is basically what was meant to be 4.3.0 but failed [due to RST errors in the CHANGELOG](https://github.com/jazzband/django-model-utils/actions/runs/3475135483/jobs/5809031610) 🤦 

This makes be think we should likely run `twine check dist/*` on CI for PR as well.
