### PR TITLE
Add type hints and the py.typed stub

### DIFF
--- a/model_utils/choices.py
+++ b/model_utils/choices.py
@@ -141,7 +141,7 @@ class Choices:
     def __deepcopy__(self, memo):
         return self.__class__(*copy.deepcopy(self._triples, memo))
 
-    def subset(self, *new_identifiers):
+    def subset(self, *new_identifiers) -> "Choices":
         identifiers = set(self._identifier_map.keys())
 
         if not identifiers.issuperset(new_identifiers):

--- a/model_utils/models.py
+++ b/model_utils/models.py
@@ -1,3 +1,4 @@
+from typing import Sequence
 from django.core.exceptions import ImproperlyConfigured
 from django.db import models, router, transaction
 from django.db.models.functions import Now
@@ -192,8 +193,8 @@ class SaveSignalHandlingModel(models.Model):
 
         super().save(*args, **kwargs)
 
-    def save_base(self, raw=False, force_insert=False,
-                  force_update=False, using=None, update_fields=None):
+    def save_base(self, raw: bool=False, force_insert: bool=False,
+                  force_update: bool=False, using=None, update_fields: Sequence[str]=None):
         """
         Copied from base class for a minor change.
         This is an ugly overwriting but since Django's ``save_base`` method

--- a/model_utils/tracker.py
+++ b/model_utils/tracker.py
@@ -1,5 +1,6 @@
 from copy import deepcopy
 from functools import wraps
+from typing import Any, Dict, Sequence
 
 from django.core.exceptions import FieldError
 from django.db import models
@@ -204,10 +205,10 @@ class FieldInstanceTracker:
     def deferred_fields(self):
         return self.instance.get_deferred_fields()
 
-    def get_field_value(self, field):
+    def get_field_value(self, field: str):
         return getattr(self.instance, self.field_map[field])
 
-    def set_saved_fields(self, fields=None):
+    def set_saved_fields(self, fields: Sequence[str]=None) -> None:
         if not self.instance.pk:
             self.saved_data = {}
         elif fields is None:
@@ -219,7 +220,7 @@ class FieldInstanceTracker:
         for field, field_value in self.saved_data.items():
             self.saved_data[field] = lightweight_deepcopy(field_value)
 
-    def current(self, fields=None):
+    def current(self, fields: Sequence[str]=None) -> Dict[str, Any]:
         """Returns dict of current values for all tracked fields"""
         if fields is None:
             deferred_fields = self.deferred_fields
@@ -233,7 +234,7 @@ class FieldInstanceTracker:
 
         return {f: self.get_field_value(f) for f in fields}
 
-    def has_changed(self, field):
+    def has_changed(self, field: str) -> bool:
         """Returns ``True`` if field has changed from currently saved value"""
         if field in self.fields:
             # deferred fields haven't changed
@@ -243,7 +244,7 @@ class FieldInstanceTracker:
         else:
             raise FieldError('field "%s" not tracked' % field)
 
-    def previous(self, field):
+    def previous(self, field: str):
         """Returns currently saved value of given field"""
 
         # handle deferred fields that have not yet been loaded from the database
@@ -263,7 +264,7 @@ class FieldInstanceTracker:
 
         return self.saved_data.get(field)
 
-    def changed(self):
+    def changed(self) -> Dict[str, Any]:
         """Returns dict of fields that changed since save (with old values)"""
         return {
             field: self.previous(field)
@@ -385,7 +386,7 @@ class FieldTracker:
 
 class ModelInstanceTracker(FieldInstanceTracker):
 
-    def has_changed(self, field):
+    def has_changed(self, field) -> bool:
         """Returns ``True`` if field has changed from currently saved value"""
         if not self.instance.pk:
             return True
@@ -394,7 +395,7 @@ class ModelInstanceTracker(FieldInstanceTracker):
         else:
             raise FieldError('field "%s" not tracked' % field)
 
-    def changed(self):
+    def changed(self) -> Dict[str, Any]:
         """Returns dict of fields that changed since save (with old values)"""
         if not self.instance.pk:
             return {}

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,9 @@ setup(
     zip_safe=False,
     package_data={
         'model_utils': [
-            'locale/*/LC_MESSAGES/django.po', 'locale/*/LC_MESSAGES/django.mo'
+            'locale/*/LC_MESSAGES/django.po', 
+            'locale/*/LC_MESSAGES/django.mo',
+            'py.typed',
         ],
     },
 )


### PR DESCRIPTION
## Problem

Model utils does not include type hints and py.typed. This prevents tools such as mypy to work properly with it.

## Solution

Add model_utils/py.typed and a few typing hints.
 
## Commandments

- [x] Write PEP8 compliant code.
- [_] Cover it with tests.
- [_] Update `CHANGES.rst` file to describe the changes, and quote according issue with `GH-<issue_number>`.
- [x] Pay attention to backward compatibility, or if it breaks it, explain why.
- [_] Update documentation (if relevant).
