### PR TITLE
Add py.typed file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,9 @@ setup(
     zip_safe=False,
     package_data={
         'model_utils': [
-            'locale/*/LC_MESSAGES/django.po', 'locale/*/LC_MESSAGES/django.mo'
+            'locale/*/LC_MESSAGES/django.po',
+            'locale/*/LC_MESSAGES/django.mo',
+            'py.typed',
         ],
     },
 )


### PR DESCRIPTION
This PR adds a py.typed file, it should fix the following error when using mypy and/or pyright

```
Stub file not found for "model_utils. models" Pylance (reportMissingTypeStubs)
```

<img width="722" alt="CleanShot 2023-01-23 at 22 04 50@2x" src="https://user-images.githubusercontent.com/667029/214160381-5b1e7975-2d90-471b-8c18-a244f63ade3b.png">

Ref: https://peps.python.org/pep-0561/
