### PR TITLE
Don't use `post_init` signal for initialize tracker

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -104,3 +104,4 @@
 | Éric Araujo <merwok@netwok.org>
 | Őry Máté <ory.mate@cloud.bme.hu>
 | Nafees Anwar <h.nafees.anwar@gmail.com>
+| meanmail <github@meanmail.dev>

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,10 +1,15 @@
 Changelog
 =========
 
+4.5.0
+-----
+
+- Don't use `post_init` signal for initialize tracker
+
 4.4.0 (2024-02-10)
 ------------------
 
-- Add support for `Python 3.11` 
+- Add support for `Python 3.11`
 - Add support for `Python 3.12`
 - Drop support for `Python 3.7`
 - Add support for `Django 4.2`

--- a/docs/utilities.rst
+++ b/docs/utilities.rst
@@ -328,9 +328,9 @@ FieldTracker implementation details
 
 This is how ``FieldTracker`` tracks field changes on ``instance.save`` call.
 
-1. In ``class_prepared`` handler ``FieldTracker`` patches ``save_base`` and
-   ``refresh_from_db`` methods to reset initial state for tracked fields.
-2. In ``post_init`` handler ``FieldTracker`` saves initial values for tracked
+1. In ``class_prepared`` handler ``FieldTracker`` patches ``save_base``,
+   ``refresh_from_db`` and ``__init__`` methods to reset initial state for tracked fields.
+2. In the patched ``__init__`` method ``FieldTracker`` saves initial values for tracked
    fields.
 3. ``MyModel.save`` changes ``update_fields`` in order to store auto updated
    ``modified`` timestamp. Complete list of saved fields is now known.


### PR DESCRIPTION
## Problem

In one of the latest versions, sentry-sdk added logging of the launch of django signal handlers. Due to the fact that the `post_init` signal handler is used to initialize the tracker, this leads to a significant decrease in performance, and also occupies the sentry logs with useless entries, which makes it impossible to analyze performance in Sentry

![image](https://user-images.githubusercontent.com/10301297/216812005-2f32a5de-48ca-49d7-b054-f66e79ada6ef.png)


## Solution

Don't use `post_init` signal for initialize tracker

## Commandments

- [x] Write PEP8 compliant code.
- [x] Cover it with tests.
- [x] Update `CHANGES.rst` file to describe the changes, and quote according issue with `GH-<issue_number>`.
- [x] Pay attention to backward compatibility, or if it breaks it, explain why.
- [x] Update documentation (if relevant).
