### PR TITLE
Fix "ImportError: No module named 'tests'"

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -30,7 +30,7 @@ passenv =
     DB_*
 usedevelop = True
 commands =
-    pytest {posargs}
+    python -m pytest {posargs}
 
 [testenv:flake8]
 basepython =


### PR DESCRIPTION
## Problem

If I try to run the unit tests via `tox`, I get this error:

```
  File "<snip>/site-packages/pytest_django/plugin.py", line 174, in _handle_import_error
    raise ImportError(msg)
ImportError: No module named 'tests'
```

This problem is triggered when `pytest-django` tries to load the module `tests.settings` as defined by `DJANGO_SETTINGS_MODULE`.

I saw a similar error in your CI, so I think it's not a problem of my local setup, but rather something that broke when one of the tooling packages changed its behavior.

## Solution

Invoke pytest using `python -m pytest` instead of just `pytest`.
    
    https://docs.pytest.org/en/6.2.x/usage.html#calling-pytest-through-python-m-pytest

Before stumbling upon this solution, tried to specify `pythonpath=.`  in `setup.cfg`, but that setting seems to only take effect after the plugin configuration.
