### PR TITLE
Test django against 4.2 & main branch to formally support django 4.2

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+To be released
+--------
+
+- Confirm support for `Django 4.2`
+
 4.3.1 (2022-11-15)
 ------------------
 

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ setup(
         'Framework :: Django :: 3.2',
         'Framework :: Django :: 4.0',
         'Framework :: Django :: 4.1',
+        'Framework :: Django :: 4.2',
     ],
     zip_safe=False,
     package_data={

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     py{37,38,39,310}-dj32
-    py{38,39,310}-dj{40,41,main}
+    py{38,39,310}-dj{40,41,42,main}
     flake8
     isort
 
@@ -19,6 +19,7 @@ deps =
     dj32: Django==3.2.*
     dj40: Django==4.0.*
     dj41: Django==4.1.*
+    dj42: Django==4.2.*
     djmain: https://github.com/django/django/archive/main.tar.gz
 ignore_outcome =
     djmain: True


### PR DESCRIPTION
With the release of django 4.2 the classifiers needs to be updated and the tests needs to be run against the 4.2 branch. 
