### PR TITLE
Confirm support for Django 4.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ setup(
         'Framework :: Django :: 3.2',
         'Framework :: Django :: 4.0',
         'Framework :: Django :: 4.1',
+        'Framework :: Django :: 4.2',
     ],
     zip_safe=False,
     package_data={

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     py{37,38,39,310}-dj32
-    py{38,39,310}-dj{40,41,main}
+    py{38,39,310}-dj{40,41,42,main}
     flake8
     isort
 
@@ -19,6 +19,7 @@ deps =
     dj32: Django==3.2.*
     dj40: Django==4.0.*
     dj41: Django==4.1.*
+    dj42: Django==4.2.*
     djmain: https://github.com/django/django/archive/main.tar.gz
 ignore_outcome =
     djmain: True


### PR DESCRIPTION
## Problem

Unclear if the latest Django version is supported.

## Solution

Test it!

I ran the new test environment locally with tox and saw no new warnings in the pytest output. So it looks like the package is already compatible!

## Commandments

- [x] Write PEP8 compliant code.
- [x] Cover it with tests.
- [x] Update `CHANGES.rst` file to describe the changes, and quote according issue with `GH-<issue_number>`.
- [x] Pay attention to backward compatibility, or if it breaks it, explain why.
- [x] Update documentation (if relevant).
