### PR TITLE
Update where `ConnectionDoesNotExist` is imported from

### DIFF
--- a/tests/test_models/test_softdeletable_model.py
+++ b/tests/test_models/test_softdeletable_model.py
@@ -1,5 +1,5 @@
-from django.db.utils import ConnectionDoesNotExist
 from django.test import TestCase
+from django.utils.connection import ConnectionDoesNotExist
 
 from tests.models import SoftDeletable
 


### PR DESCRIPTION
## Problem

`ConnectionDoesNotExist` does not exist in `django.db.utils` in `django-stubs`, as it was moved to `django.utils.connection` in Django 3.2.  At some point in the future, I expect it will also only be available from its new location in Django itself.

## Solution

Import it from its new location.

## Commandments

- [x] Write PEP8 compliant code.
- [x] Cover it with tests.
- [x] Update `CHANGES.rst` file to describe the changes, and quote according issue with `GH-<issue_number>`.
- [x] Pay attention to backward compatibility, or if it breaks it, explain why.
- [x] Update documentation (if relevant).
