### PR TITLE
Remove arguments from `InheritanceQuerySetMixin._clone()`

### DIFF
--- a/model_utils/managers.py
+++ b/model_utils/managers.py
@@ -89,7 +89,7 @@ class InheritanceQuerySetMixin:
         chained.__dict__.update(update)
         return chained
 
-    def _clone(self, klass=None, setup=False, **kwargs):
+    def _clone(self):
         qs = super()._clone()
         for name in ['subclasses', '_annotated']:
             if hasattr(self, name):


### PR DESCRIPTION
## Problem

`InheritanceQuerySetMixin._clone()` accepts and then ignores a `klass` and `setup` argument, plus any keyword arguments. The `QuerySet._clone()` method has no arguments in either Django 3.2 or 4.1 and when using a static code checker like `mypy`, this is reported as incompatible base classes for `InheritanceManager`.

## Solution

I'm assuming the arguments were necessary for a version of Django that is no longer supported by `django-model-utils`. Therefore I removed the extra arguments.

## Commandments

- [x] Write PEP8 compliant code.
- [x] Cover it with tests. (The `_clone()` method was already covered.)
- [x] Update `CHANGES.rst` file to describe the changes, and quote according issue with `GH-<issue_number>`.
- [x] Pay attention to backward compatibility, or if it breaks it, explain why.
- [x] Update documentation (if relevant).

I chose to not add an entry in `CHANGES.rst`, as this is a cleanup that should not be noticeable to users.
