### PR TITLE
Connect signals to specified class only

### DIFF
--- a/model_utils/tracker.py
+++ b/model_utils/tracker.py
@@ -340,7 +340,7 @@ class FieldTracker:
             wrapped_descriptor = wrapper_cls(field_name, descriptor, self.attname)
             setattr(sender, field_name, wrapped_descriptor)
         self.field_map = self.get_field_map(sender)
-        models.signals.post_init.connect(self.initialize_tracker)
+        models.signals.post_init.connect(self.initialize_tracker, sender=sender)
         self.model_class = sender
         setattr(sender, self.name, self)
         self.patch_save(sender)


### PR DESCRIPTION
## Problem

Currently the `initialize_tracker` was called for all models which is not efficient and flooded in Sentry performance logs

## Solution

Connect the signal to specified class only with least changes
Related issue: https://github.com/jazzband/django-model-utils/pull/556

## Commandments

- [ ] Write PEP8 compliant code.
- [ ] Cover it with tests.
- [ ] Update `CHANGES.rst` file to describe the changes, and quote according issue with `GH-<issue_number>`.
- [ ] Pay attention to backward compatibility, or if it breaks it, explain why.
- [ ] Update documentation (if relevant).
