### PR TITLE
feat(monitor): Change default to None when the field is nullable

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -34,6 +34,7 @@
 | Germano Massullo <github.com/Germano0>
 | Gregor Müllegger <gregor@muellegger.de>
 | Guilherme Devincenzi <github.com/gdevincenzi>
+| Guilherme Crocetti <github.com/gmcrocetti>
 | Hanley <hanley@wayup.com>
 | Hanley Hansen <hanleyhansen@gmail.com>
 | Harry Moreno <morenoh149@gmail.com>

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,7 @@ To be released
 - Drop support for `Python 3.7` (GH-#545)
 - Swedish translation (GH-#561)
 - Use proper column name instead of attname (GH-#573)
+- Change MonitorField default to be NULL when the field is nullable (GH-#576)
 
 4.3.1 (2022-11-15)
 ------------------

--- a/model_utils/fields.py
+++ b/model_utils/fields.py
@@ -107,7 +107,8 @@ class MonitorField(models.DateTimeField):
     """
 
     def __init__(self, *args, **kwargs):
-        kwargs.setdefault('default', now)
+        default = None if kwargs.get("null") else now
+        kwargs.setdefault('default', default)
         monitor = kwargs.pop('monitor', None)
         if not monitor:
             raise TypeError(

--- a/tests/models.py
+++ b/tests/models.py
@@ -99,6 +99,7 @@ class TimeFrameManagerAdded(TimeFramedModel):
 class Monitored(models.Model):
     name = models.CharField(max_length=25)
     name_changed = MonitorField(monitor="name")
+    name_changed_nullable = MonitorField(monitor="name", null=True)
 
 
 class MonitorWhen(models.Model):

--- a/tests/test_fields/test_monitor_field.py
+++ b/tests/test_fields/test_monitor_field.py
@@ -34,6 +34,15 @@ class MonitorFieldTests(TestCase):
         with self.assertRaises(TypeError):
             MonitorField()
 
+    def test_monitor_default_is_none_when_nullable(self):
+        self.assertIsNone(self.instance.name_changed_nullable)
+
+        self.instance.name = "Jose"
+        with freeze_time(datetime(2023, 6, 18, 12, 0, 0)):
+            self.instance.save()
+
+        self.assertEqual(self.instance.name_changed_nullable, datetime(2023, 6, 18, 12, 0, 0))
+
 
 class MonitorWhenFieldTests(TestCase):
     """


### PR DESCRIPTION
## Problem

I recently came across a non-intuitive behavior, IMHO. The `MonitorField` has its default value set to `now` even though marked as nullable. Please, I'm open to hearing the opinion case it's is expected behavior.

## Solution

After catching up the discussion in #100 I decided to implement it. The discussed solution is to set its default value to `None` when `null=True`.

If might break backward compatibility the edge case of someone marking the field as `null=True` and not expecting default to be None.

## Commandments

- [x] Write PEP8 compliant code.
- [x] Cover it with tests.
- [x] Update `CHANGES.rst` file to describe the changes, and quote according issue with `GH-<issue_number>`.
- [x] Pay attention to backward compatibility, or if it breaks it, explain why.
- [ ] Update documentation (if relevant).
