### PR TITLE
`MonitorField` - Change default to None when the field is nullable 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,8 @@ Changelog
 
 To be released
 --------------
+- Add deprecation warning for MonitorField. The default value will be `None`
+  instead of `django.utils.timezone.now` - when nullable and without a default.
 - Add Brazilian Portuguese translation (GH-#578)
 - Don't use `post_init` signal for initialize tracker
 

--- a/model_utils/fields.py
+++ b/model_utils/fields.py
@@ -1,5 +1,6 @@
 import secrets
 import uuid
+import warnings
 from collections.abc import Callable
 
 from django.conf import settings
@@ -107,6 +108,16 @@ class MonitorField(models.DateTimeField):
     """
 
     def __init__(self, *args, **kwargs):
+        if kwargs.get("null") and kwargs.get("default") is None:
+            warning_message = (
+                "{}.default is set to 'django.utils.timezone.now' - when nullable"
+                " and no default. This behavior will be deprecated in the next"
+                " major release in favor of 'None'. See"
+                " https://django-model-utils.readthedocs.io/en/stable/fields.html"
+                "#monitorfield for more information."
+            ).format(self.__class__.__name__)
+            warnings.warn(warning_message, DeprecationWarning)
+
         kwargs.setdefault('default', now)
         monitor = kwargs.pop('monitor', None)
         if not monitor:

--- a/tests/test_fields/test_monitor_field.py
+++ b/tests/test_fields/test_monitor_field.py
@@ -34,6 +34,18 @@ class MonitorFieldTests(TestCase):
         with self.assertRaises(TypeError):
             MonitorField()
 
+    def test_nullable_without_default_deprecation(self):
+        warning_message = (
+            "{}.default is set to 'django.utils.timezone.now' - when nullable"
+            " and no default. This behavior will be deprecated in the next"
+            " major release in favor of 'None'. See"
+            " https://django-model-utils.readthedocs.io/en/stable/fields.html"
+            "#monitorfield for more information."
+        ).format(MonitorField.__name__)
+
+        with self.assertWarns(DeprecationWarning, msg=warning_message):
+            MonitorField(monitor="foo", null=True, default=None)
+
 
 class MonitorWhenFieldTests(TestCase):
     """


### PR DESCRIPTION
## Problem

I recently came across a non-intuitive behavior, IMHO. The MonitorField has its default value set to now even though marked as nullable. Please, I'm open to hearing the opinion case this is expected behavior.

## Solution

After catching up the discussion in https://github.com/jazzband/django-model-utils/issues/100 I decided to implement it. The discussed solution is to set its default value to None when null=True.

If **might break** backward compatibility at the edge case of someone marking the field as null=True and not expecting default to be None.

## Commandments

- [x] Write PEP8 compliant code.
- [x] Cover it with tests.
- [x] Update `CHANGES.rst` file to describe the changes, and quote according issue with `GH-<issue_number>`.
- [x] Pay attention to backward compatibility, or if it breaks it, explain why.
- [x] Update documentation (if relevant).
