### PR TITLE
Test Django 5.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,7 @@ To be released
 
 - Remove ``SaveSignalHandlingModel``. This model used a modified copy of the internal Django method `Model.save_base()`
   and had not been updated for upstream bug fixes changes since its addition. (GH-#582)
-- Confirm support for `Django 4.2`
+- Confirm support for `Django 4.2` and `Django 5.0`.
 - Add support for `Python 3.11` (GH-#545)
 - Add support for `Python 3.12` (GH-#545)
 - Drop support for `Python 3.7` (GH-#545)

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,4 +1,4 @@
-pytest==6.2.5
-pytest-django==3.10.0
-psycopg2-binary==2.9.5
-pytest-cov==2.10.1
+pytest==7.4.3
+pytest-django==4.5.2
+psycopg2-binary==2.9.9
+pytest-cov==4.1.0

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,7 @@ setup(
         'Framework :: Django :: 4.0',
         'Framework :: Django :: 4.1',
         'Framework :: Django :: 4.2',
+        'Framework :: Django :: 5.0',
     ],
     zip_safe=False,
     package_data={

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,11 @@
 [tox]
 envlist =
     py{37,38,39,310}-dj32
-    py{38,39,310,311,312}-dj{40,41,42,main}
+    py{38,39,310}-dj{40}
+    py{38,39,310,311}-dj{41}
+    py{38,39,310,311}-dj{42}
+    py{310,311,312}-dj{50}
+    py{310,311,312}-dj{main}
     flake8
     isort
 
@@ -22,6 +26,7 @@ deps =
     dj40: Django==4.0.*
     dj41: Django==4.1.*
     dj42: Django==4.2.*
+    dj50: Django==5.0.*
     djmain: https://github.com/django/django/archive/main.tar.gz
 ignore_outcome =
     djmain: True


### PR DESCRIPTION
## Problem

Test the new version of Django that’s in beta.

Depends on #582. If you want to consider updating `SaveSignalHandlingModel`, we can look at that, but I really suggest that it be removed.

## Solution

Added classifier to `setup.py`, new test environment to `tox.ini`, setup, and upgraded test requirements to fix some warnings.

## Commandments

- [x] Write PEP8 compliant code.
- [x] Cover it with tests.
- [x] Update `CHANGES.rst` file to describe the changes, and quote according issue with `GH-<issue_number>`.
- [x] Pay attention to backward compatibility, or if it breaks it, explain why.
- [x] Update documentation (if relevant).
