### PR TITLE
clarify docs for managers of SoftDeletableModel

### DIFF
--- a/docs/models.rst
+++ b/docs/models.rst
@@ -89,8 +89,8 @@ manager ``available_objects`` are limited to not-deleted instances.
 
 Note that relying on the default ``objects`` manager to filter out not-deleted
 instances is deprecated. ``objects`` will include deleted objects in a future
-release.
-
+release. Until then, the recommended course of action is to use the manager
+``all_objects`` when you want to include all instances.
 
 UUIDModel
 ------------------


### PR DESCRIPTION
follow-up to https://github.com/jazzband/django-model-utils/pull/438/

## Problem

https://github.com/jazzband/django-model-utils/pull/438/ added docs explaining the deprecation, but as a result it became unclear which manager one should use to return all objects (until https://github.com/jazzband/django-model-utils/pull/480 can be merged)