### PR TITLE
Explicitly re-export names from `__init__` module

### DIFF
--- a/model_utils/__init__.py
+++ b/model_utils/__init__.py
@@ -1,10 +1,12 @@
 import importlib.metadata
 
-from .choices import Choices  # noqa:F401
-from .tracker import FieldTracker, ModelTracker  # noqa:F401
+from .choices import Choices
+from .tracker import FieldTracker, ModelTracker
 
 try:
     __version__ = importlib.metadata.version('django-model-utils')
 except importlib.metadata.PackageNotFoundError:  # pragma: no cover
     # package is not installed
     __version__ = None
+
+__all__ = ("Choices", "FieldTracker", "ModelTracker")


### PR DESCRIPTION
By listing names intended for export in the `__all__` module-level variable, static code checkers like mypy are able to verify that importing a name from a module that itself imported it is by design rather than by accident.

As flake8 understand `__all__`, this also removes the need for warning suppression comments.
