### PR TITLE
Pass reason to `@skip` decorator

### DIFF
--- a/tests/test_fields/test_field_tracker.py
+++ b/tests/test_fields/test_field_tracker.py
@@ -870,7 +870,7 @@ class InheritedModelTrackerTests(ModelTrackerTests):
         self.assertTrue(self.tracker.has_changed('name2'))
 
 
-@skip
+@skip("has known failures")
 class AbstractModelTrackerTests(ModelTrackerTests):
 
     tracked_class = TrackedAbstract


### PR DESCRIPTION
The `@skip` decorator works without an argument as well, but that is an undocumented feature of [`unittest.skip()`](https://docs.python.org/3/library/unittest.html#unittest.skip) that is not understood by mypy and pytest.

In the case of pytest, it ignored the decorated class during test collection, instead of collecting it and marking it as skipped.
