### PR TITLE
Resolve name clash among test models

### DIFF
--- a/tests/models.py
+++ b/tests/models.py
@@ -145,7 +145,9 @@ class StatusCustomManager(Manager):
     pass
 
 
-class AbstractStatusCustomManager(StatusModel):
+class AbstractCustomManagerStatusModel(StatusModel):
+    """An abstract status model with a custom manager."""
+
     STATUS = Choices(
         ("first_choice", _("First choice")),
         ("second_choice", _("Second choice")),
@@ -157,7 +159,9 @@ class AbstractStatusCustomManager(StatusModel):
         abstract = True
 
 
-class StatusCustomManager(AbstractStatusCustomManager):
+class CustomManagerStatusModel(AbstractCustomManagerStatusModel):
+    """A concrete status model with a custom manager."""
+
     title = models.CharField(max_length=50)
 
 

--- a/tests/test_models/test_status_model.py
+++ b/tests/test_models/test_status_model.py
@@ -3,7 +3,7 @@ from datetime import datetime, timezone
 import time_machine
 from django.test.testcases import TestCase
 
-from tests.models import Status, StatusCustomManager, StatusPlainTuple
+from tests.models import CustomManagerStatusModel, Status, StatusPlainTuple
 
 
 class StatusModelTests(TestCase):
@@ -87,13 +87,13 @@ class StatusModelDefaultManagerTests(TestCase):
         # This situation only happens when we define a model inheriting from an "abstract"
         # class which defines an "objects" manager.
 
-        StatusCustomManager.objects.create(status='first_choice')
-        StatusCustomManager.objects.create(status='second_choice')
-        StatusCustomManager.objects.create(status='second_choice')
+        CustomManagerStatusModel.objects.create(status='first_choice')
+        CustomManagerStatusModel.objects.create(status='second_choice')
+        CustomManagerStatusModel.objects.create(status='second_choice')
 
         # ...which made this count() equal to 1 (only 1 element with status='first_choice')...
-        self.assertEqual(StatusCustomManager._default_manager.count(), 3)
+        self.assertEqual(CustomManagerStatusModel._default_manager.count(), 3)
 
         # ...and this one equal to 0, because of 2 successive filters of 'first_choice'
         # (default manager) and 'second_choice' (explicit filter below).
-        self.assertEqual(StatusCustomManager._default_manager.filter(status='second_choice').count(), 2)
+        self.assertEqual(CustomManagerStatusModel._default_manager.filter(status='second_choice').count(), 2)


### PR DESCRIPTION
In `tests/models.py`, there were two classes named `StatusCustomManager`: the first is an actual manager, the second a status model that uses a custom manager. The latter is renamed to `CustomManagerStatusModel` in this PR.

The name clash tripped up mypy, but is also confusing for human readers.