### PR TITLE
Remove obsolete `tests.signals` module

### DIFF
--- a/tests/signals.py
+++ b/tests/signals.py
@@ -1,6 +1,0 @@
-def pre_save_test(instance, *args, **kwargs):
-    instance.pre_save_runned = True
-
-
-def post_save_test(instance, created, *args, **kwargs):
-    instance.post_save_runned = True


### PR DESCRIPTION
This module was support code for the `SaveSignalHandlingModel` tests. That class got introduced in 5d6f8f4e and removed in 11f3a53b, but the support code remained.
