### PR TITLE
Remove obsolete test models

### DIFF
--- a/tests/models.py
+++ b/tests/models.py
@@ -201,32 +201,6 @@ class NoRendered(models.Model):
     body = SplitField(no_excerpt_field=True)
 
 
-class AuthorMixin:
-    def by_author(self, name):
-        return self.filter(author=name)
-
-
-class PublishedMixin:
-    def published(self):
-        return self.filter(published=True)
-
-
-def unpublished(self):
-    return self.filter(published=False)
-
-
-class ByAuthorQuerySet(models.query.QuerySet, AuthorMixin):
-    pass
-
-
-class FeaturedManager(models.Manager):
-    def get_queryset(self):
-        kwargs = {}
-        if hasattr(self, "_db"):
-            kwargs["using"] = self._db
-        return ByAuthorQuerySet(self.model, **kwargs).filter(feature=True)
-
-
 class AbstractTracked(models.Model):
     number = 1
 

--- a/tests/models.py
+++ b/tests/models.py
@@ -192,15 +192,6 @@ class SplitFieldAbstractParent(models.Model):
         abstract = True
 
 
-class NoRendered(models.Model):
-    """
-    Test that the no_excerpt_field keyword arg works. This arg should
-    never be used except by the South model-freezing.
-
-    """
-    body = SplitField(no_excerpt_field=True)
-
-
 class AbstractTracked(models.Model):
     number = 1
 


### PR DESCRIPTION
This PR removes a bunch of obsolete classes from `tests/models.py`. The tests that used them were removed long ago, but the test models escaped deletion, until now.