### PR TITLE
Add issue-manager

### DIFF
--- a/.github/workflows/issue-manager.yml
+++ b/.github/workflows/issue-manager.yml
@@ -1,0 +1,47 @@
+# Automatically close issues or pull requests that have a label, after a custom delay, if no one replies.
+# https://github.com/tiangolo/issue-manager
+name: Issue Manager
+
+on:
+  schedule:
+    - cron: "12 0 * * *"
+  issue_comment:
+    types:
+      - created
+  issues:
+    types:
+      - labeled
+  pull_request_target:
+    types:
+      - labeled
+  workflow_dispatch:
+
+jobs:
+  issue-manager:
+    # Disables this workflow from running in a repository that is not part of the indicated organization/user
+    if: github.repository_owner == 'jazzband'
+
+    runs-on: ubuntu-latest
+    steps:
+      - uses: tiangolo/issue-manager@0.5.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          config: >
+            {
+              "answered": {
+                "delay": 864000,
+                "message": "Assuming the question was answered, this will be automatically closed now."
+              },
+              "solved": {
+                "delay": 864000,
+                "message": "Assuming the original issue was solved, it will be automatically closed now."
+              },
+              "waiting": {
+                "delay": 864000,
+                "message": "Automatically closing after waiting for additional info. To re-open, please provide the additional information requested."
+              },
+              "wontfix": {
+                "delay": 864000,
+                "message": "As discussed, we won't be implementing this. Automatically closing."
+              }
+            }


### PR DESCRIPTION
> Automatically close issues or Pull Requests that have a label, after a custom delay, if no one replies back.

This PR adds https://github.com/tiangolo/issue-manager to the github workflows. The config is borrowed from [cookiecutter-django](https://github.com/cookiecutter/cookiecutter-django/). 

It will help closing issues and PR's without any wrongdoing against the original poster. 

