### PR TITLE
Modernize the way some keyword-only arguments are implemented

### DIFF
--- a/model_utils/fields.py
+++ b/model_utils/fields.py
@@ -70,10 +70,10 @@ class StatusField(models.CharField):
     South can handle this field when it freezes a model.
     """
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, no_check_for_status=False, choices_name=DEFAULT_CHOICES_NAME, **kwargs):
         kwargs.setdefault('max_length', 100)
-        self.check_for_status = not kwargs.pop('no_check_for_status', False)
-        self.choices_name = kwargs.pop('choices_name', DEFAULT_CHOICES_NAME)
+        self.check_for_status = not no_check_for_status
+        self.choices_name = choices_name
         super().__init__(*args, **kwargs)
 
     def prepare_class(self, sender, **kwargs):
@@ -107,7 +107,7 @@ class MonitorField(models.DateTimeField):
 
     """
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, monitor, when=None, **kwargs):
         if kwargs.get("null") and kwargs.get("default") is None:
             warning_message = (
                 "{}.default is set to 'django.utils.timezone.now' - when nullable"
@@ -119,12 +119,7 @@ class MonitorField(models.DateTimeField):
             warnings.warn(warning_message, DeprecationWarning)
 
         kwargs.setdefault('default', now)
-        monitor = kwargs.pop('monitor', None)
-        if not monitor:
-            raise TypeError(
-                '%s requires a "monitor" argument' % self.__class__.__name__)
         self.monitor = monitor
-        when = kwargs.pop('when', None)
         if when is not None:
             when = set(when)
         self.when = when
@@ -241,12 +236,12 @@ class SplitDescriptor:
 
 
 class SplitField(models.TextField):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, no_excerpt_field=False, **kwargs):
         # for South FakeORM compatibility: the frozen version of a
         # SplitField can't try to add an _excerpt field, because the
         # _excerpt field itself is frozen as well. See introspection
         # rules below.
-        self.add_excerpt_field = not kwargs.pop('no_excerpt_field', False)
+        self.add_excerpt_field = not no_excerpt_field
         super().__init__(*args, **kwargs)
 
     def contribute_to_class(self, cls, name):

--- a/tests/test_fields/test_field_tracker.py
+++ b/tests/test_fields/test_field_tracker.py
@@ -30,8 +30,9 @@ class FieldTrackerTestCase(TestCase):
 
     tracker = None
 
-    def assertHasChanged(self, **kwargs):
-        tracker = kwargs.pop('tracker', self.tracker)
+    def assertHasChanged(self, *, tracker=None, **kwargs):
+        if tracker is None:
+            tracker = self.tracker
         for field, value in kwargs.items():
             if value is None:
                 with self.assertRaises(FieldError):
@@ -39,17 +40,20 @@ class FieldTrackerTestCase(TestCase):
             else:
                 self.assertEqual(tracker.has_changed(field), value)
 
-    def assertPrevious(self, **kwargs):
-        tracker = kwargs.pop('tracker', self.tracker)
+    def assertPrevious(self, *, tracker=None, **kwargs):
+        if tracker is None:
+            tracker = self.tracker
         for field, value in kwargs.items():
             self.assertEqual(tracker.previous(field), value)
 
-    def assertChanged(self, **kwargs):
-        tracker = kwargs.pop('tracker', self.tracker)
+    def assertChanged(self, *, tracker=None, **kwargs):
+        if tracker is None:
+            tracker = self.tracker
         self.assertEqual(tracker.changed(), kwargs)
 
-    def assertCurrent(self, **kwargs):
-        tracker = kwargs.pop('tracker', self.tracker)
+    def assertCurrent(self, *, tracker=None, **kwargs):
+        if tracker is None:
+            tracker = self.tracker
         self.assertEqual(tracker.current(), kwargs)
 
     def update_instance(self, **kwargs):


### PR DESCRIPTION
Python 2 didn't have keyword-only arguments, so some code emulated them by wrangling `kwargs`. This PR updates that code to use modern syntax instead.

There should be no backwards compatibility issues.