### PR TITLE
Minor cleanup of the code handling `UrlsafeTokenField`'s `factory` argument

### DIFF
--- a/model_utils/fields.py
+++ b/model_utils/fields.py
@@ -1,7 +1,6 @@
 import secrets
 import uuid
 import warnings
-from collections.abc import Callable
 
 from django.conf import settings
 from django.core.exceptions import ValidationError
@@ -346,7 +345,7 @@ class UrlsafeTokenField(models.CharField):
             non-callable value for factory is not supported.
         """
 
-        if factory is not None and not isinstance(factory, Callable):
+        if factory is not None and not callable(factory):
             raise TypeError("'factory' should either be a callable or 'None'")
         self._factory = factory
 

--- a/model_utils/fields.py
+++ b/model_utils/fields.py
@@ -347,7 +347,7 @@ class UrlsafeTokenField(models.CharField):
         """
 
         if factory is not None and not isinstance(factory, Callable):
-            raise TypeError("'factory' should either be a callable not 'None'")
+            raise TypeError("'factory' should either be a callable or 'None'")
         self._factory = factory
 
         kwargs.pop('default', None)  # passing default value has not effect.


### PR DESCRIPTION
The use of `isinstance(factory, Callable)` is avoided, because it triggers a long standing bug in mypy.

Additionally, a wrong word in an error message was fixed.

This should have no impact on users of the library.