### PR TITLE
Fix `SoftDeletableModel.delete()` forwarding positional args to superclass

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,7 @@ To be released
 - Make `contribute_to_class()` in `StatusField`, `MonitorField` and `SplitField`
   forward additional arguments to Django
 - `SplitField` no longer accepts `no_excerpt_field` as a keyword argument
+- Make `soft` argument to `SoftDeletableModel.delete()` keyword-only
 
 4.4.0 (2024-02-10)
 ------------------

--- a/model_utils/models.py
+++ b/model_utils/models.py
@@ -146,7 +146,7 @@ class SoftDeletableModel(models.Model):
     available_objects = SoftDeletableManager()
     all_objects = models.Manager()
 
-    def delete(self, using=None, soft=True, *args, **kwargs):
+    def delete(self, using=None, *args, soft=True, **kwargs):
         """
         Soft delete object (set its ``is_removed`` field to True).
         Actually delete object if setting ``soft`` to False.
@@ -155,7 +155,7 @@ class SoftDeletableModel(models.Model):
             self.is_removed = True
             self.save(using=using)
         else:
-            return super().delete(using=using, *args, **kwargs)
+            return super().delete(using, *args, **kwargs)
 
 
 class UUIDModel(models.Model):


### PR DESCRIPTION
The `soft` argument was made keyword-only, to avoid conflicts with new positional arguments that might be added to Django. It was already conflicting with the `keep_parents` argument.

This is a backward incompatible change: code that used to pass `soft` positionally will require updating. Hopefully most code was either using the default (`True`) or was already passing `soft=False` as a keyword argument.