### PR TITLE
Auto-generate manager implementation for `CustomSoftDelete`

### DIFF
--- a/tests/managers.py
+++ b/tests/managers.py
@@ -1,13 +1,6 @@
-from model_utils.managers import SoftDeletableManager, SoftDeletableQuerySet
+from model_utils.managers import SoftDeletableQuerySet
 
 
 class CustomSoftDeleteQuerySet(SoftDeletableQuerySet):
     def only_read(self):
         return self.filter(is_read=True)
-
-
-class CustomSoftDeleteManager(SoftDeletableManager):
-    _queryset_class = CustomSoftDeleteQuerySet
-
-    def only_read(self):
-        return self.get_queryset().only_read()

--- a/tests/managers.py
+++ b/tests/managers.py
@@ -1,6 +1,0 @@
-from model_utils.managers import SoftDeletableQuerySet
-
-
-class CustomSoftDeleteQuerySet(SoftDeletableQuerySet):
-    def only_read(self):
-        return self.filter(is_read=True)

--- a/tests/models.py
+++ b/tests/models.py
@@ -14,6 +14,7 @@ from model_utils.managers import (
     JoinManager,
     QueryManager,
     SoftDeletableManager,
+    SoftDeletableQuerySet,
 )
 from model_utils.models import (
     SoftDeletableModel,
@@ -24,7 +25,6 @@ from model_utils.models import (
 )
 from model_utils.tracker import FieldTracker, ModelTracker
 from tests.fields import MutableField
-from tests.managers import CustomSoftDeleteQuerySet
 
 
 class InheritanceManagerTestRelated(models.Model):
@@ -350,6 +350,11 @@ class SoftDeletable(SoftDeletableModel):
     name = models.CharField(max_length=20)
 
     all_objects: ClassVar[Manager[SoftDeletable]] = models.Manager()
+
+
+class CustomSoftDeleteQuerySet(SoftDeletableQuerySet):
+    def only_read(self):
+        return self.filter(is_read=True)
 
 
 class CustomSoftDelete(SoftDeletableModel):

--- a/tests/models.py
+++ b/tests/models.py
@@ -9,7 +9,12 @@ from django.utils.translation import gettext_lazy as _
 
 from model_utils import Choices
 from model_utils.fields import MonitorField, SplitField, StatusField, UUIDField
-from model_utils.managers import InheritanceManager, JoinManager, QueryManager
+from model_utils.managers import (
+    InheritanceManager,
+    JoinManager,
+    QueryManager,
+    SoftDeletableManager,
+)
 from model_utils.models import (
     SoftDeletableModel,
     StatusModel,
@@ -19,7 +24,7 @@ from model_utils.models import (
 )
 from model_utils.tracker import FieldTracker, ModelTracker
 from tests.fields import MutableField
-from tests.managers import CustomSoftDeleteManager
+from tests.managers import CustomSoftDeleteQuerySet
 
 
 class InheritanceManagerTestRelated(models.Model):
@@ -350,7 +355,7 @@ class SoftDeletable(SoftDeletableModel):
 class CustomSoftDelete(SoftDeletableModel):
     is_read = models.BooleanField(default=False)
 
-    objects: ClassVar[CustomSoftDeleteManager[SoftDeletableModel]] = CustomSoftDeleteManager()
+    objects = SoftDeletableManager.from_queryset(CustomSoftDeleteQuerySet)()  # type: ignore[misc]
 
 
 class StringyDescriptor:

--- a/tests/models.py
+++ b/tests/models.py
@@ -360,7 +360,7 @@ class CustomSoftDeleteQuerySet(SoftDeletableQuerySet):
 class CustomSoftDelete(SoftDeletableModel):
     is_read = models.BooleanField(default=False)
 
-    objects = SoftDeletableManager.from_queryset(CustomSoftDeleteQuerySet)()  # type: ignore[misc]
+    available_objects = SoftDeletableManager.from_queryset(CustomSoftDeleteQuerySet)()  # type: ignore[misc]
 
 
 class StringyDescriptor:

--- a/tests/test_managers/test_softdelete_manager.py
+++ b/tests/test_managers/test_softdelete_manager.py
@@ -6,21 +6,21 @@ from tests.models import CustomSoftDelete
 class CustomSoftDeleteManagerTests(TestCase):
 
     def test_custom_manager_empty(self):
-        qs = CustomSoftDelete.objects.only_read()
+        qs = CustomSoftDelete.available_objects.only_read()
         self.assertEqual(qs.count(), 0)
 
     def test_custom_qs_empty(self):
-        qs = CustomSoftDelete.objects.all().only_read()
+        qs = CustomSoftDelete.available_objects.all().only_read()
         self.assertEqual(qs.count(), 0)
 
     def test_is_read(self):
         for is_read in [True, False, True, False]:
-            CustomSoftDelete.objects.create(is_read=is_read)
-        qs = CustomSoftDelete.objects.only_read()
+            CustomSoftDelete.available_objects.create(is_read=is_read)
+        qs = CustomSoftDelete.available_objects.only_read()
         self.assertEqual(qs.count(), 2)
 
     def test_is_read_removed(self):
         for is_read, is_removed in [(True, True), (True, False), (False, False), (False, True)]:
-            CustomSoftDelete.objects.create(is_read=is_read, is_removed=is_removed)
-        qs = CustomSoftDelete.objects.only_read()
+            CustomSoftDelete.available_objects.create(is_read=is_read, is_removed=is_removed)
+        qs = CustomSoftDelete.available_objects.only_read()
         self.assertEqual(qs.count(), 1)


### PR DESCRIPTION
Besides requiring less code, this also allows the django-stubs mypy plugin to automatically generate a type-annotated version of the manager.

Name the manager `available_objects` because `objects` is deprecated in `SoftDeletableModel`.
