### PR TITLE
Remove `JoinManager` class

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,7 @@ To be released
 - Make `contribute_to_class()` in `StatusField`, `MonitorField` and `SplitField`
   forward additional arguments to Django
 - `SplitField` no longer accepts `no_excerpt_field` as a keyword argument
+- Remove `JoinManager` and `JoinManagerMixin`; use ``JoinQueryset.as_manager()`` instead
 
 4.4.0 (2024-02-10)
 ------------------

--- a/model_utils/managers.py
+++ b/model_utils/managers.py
@@ -382,18 +382,3 @@ class JoinQueryset(models.QuerySet):
         )
         new_qs.query.join(conn, reuse=None)
         return new_qs
-
-
-class JoinManagerMixin:
-    """
-    Manager that adds a method join. This method allows you to join two
-    querysets together.
-    """
-    _queryset_class = JoinQueryset
-
-    def get_queryset(self):
-        return self._queryset_class(model=self.model, using=self._db)
-
-
-class JoinManager(JoinManagerMixin, models.Manager):
-    pass

--- a/tests/models.py
+++ b/tests/models.py
@@ -9,7 +9,7 @@ from django.utils.translation import gettext_lazy as _
 
 from model_utils import Choices
 from model_utils.fields import MonitorField, SplitField, StatusField, UUIDField
-from model_utils.managers import InheritanceManager, JoinManager, QueryManager
+from model_utils.managers import InheritanceManager, JoinQueryset, QueryManager
 from model_utils.models import (
     SoftDeletableModel,
     StatusModel,
@@ -394,7 +394,7 @@ class ModelWithCustomDescriptor(models.Model):
 
 class BoxJoinModel(models.Model):
     name = models.CharField(max_length=32)
-    objects: ClassVar[JoinManager[BoxJoinModel]] = JoinManager()
+    objects = JoinQueryset.as_manager()
 
 
 class JoinItemForeignKey(models.Model):
@@ -404,7 +404,7 @@ class JoinItemForeignKey(models.Model):
         null=True,
         on_delete=models.CASCADE
     )
-    objects: ClassVar[JoinManager[JoinItemForeignKey]] = JoinManager()
+    objects = JoinQueryset.as_manager()
 
 
 class CustomUUIDModel(UUIDModel):


### PR DESCRIPTION
The `JoinManager` class doesn't provide anything that is not already provided by `JoinQueryset.as_manager()`.

My main motivation for removing `JoinManager` is that it would be too much work to make `JoinManager` work properly with type annotations, while `as_manager()` works out of the box thanks to the django-stubs plugin.

This is a backwards incompatible change, as code using `JoinManager` or `JoinManagerMixin` would have to be updated. In most cases, I expect that update to be a single-line change; see the unit test changes for an example.

I don't know whether `JoinQueryset` is still relevant functionality. It generates SQL as a string and contains custom quote code, which always makes me worried about the potential for injection attacks. Perhaps that class could be removed as well?