### PR TITLE
Remove support for assigning `None` to a `SplitField`

### DIFF
--- a/model_utils/fields.py
+++ b/model_utils/fields.py
@@ -208,9 +208,6 @@ class SplitDescriptor:
     def __get__(self, instance, owner):
         if instance is None:
             raise AttributeError('Can only be accessed via an instance.')
-        content = instance.__dict__[self.field.name]
-        if content is None:
-            return None
         return SplitText(instance, self.field.name, self.excerpt_field_name)
 
     def __set__(self, obj, value):

--- a/tests/test_fields/test_split_field.py
+++ b/tests/test_fields/test_split_field.py
@@ -53,10 +53,6 @@ class SplitFieldTests(TestCase):
         with self.assertRaises(AttributeError):
             Article.body
 
-    def test_none(self):
-        a = Article(title='Some Title', body=None)
-        self.assertEqual(a.body, None)
-
     def test_assign_splittext(self):
         a = Article(title='Some Title')
         a.body = self.post.body


### PR DESCRIPTION
This behavior wasn't documented and didn't fully work: it breaks as soon as you try to save a model with a `None` value.

I think removing `None` support is better than making it work:
- to make it work properly, it would have to respect the `null` constructor argument both in the implementation and in the type checking, which is a lot of work
- [the Django docs](https://docs.djangoproject.com/en/5.0/ref/models/fields/#null) recommend against using `null=True` for text fields, so the value of the feature is questionable

As it was an undocumented feature that only partially worked, I think this change doesn't break backwards compatibility, so I didn't add it to the ChangeLog.
