### PR TITLE
Update README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -34,15 +34,6 @@ Getting Help
 Documentation for django-model-utils is available
 https://django-model-utils.readthedocs.io/
 
-
-Run tests
----------
-
-.. code-block
-
-    pip install -e .
-    py.test
-
 Contributing
 ============
 


### PR DESCRIPTION
Update readme.rst

Run tests section does not render on github correctly and this information is available in docs.

## Problem

The readme.rst tests section does not render on github and this information is already available in the documentation.

## Solution

Removed the section heading and related Run Tests section from readme.rst.

## Commandments

- [ ] Write PEP8 compliant code.
- [ ] Cover it with tests.
- [ ] Update `CHANGES.rst` file to describe the changes, and quote according issue with `GH-<issue_number>`.
- [ ] Pay attention to backward compatibility, or if it breaks it, explain why.
- [x] Update documentation (if relevant).
