### PR TITLE
Fixed an infinite recursion bug when deleting models related to a tracked model with a ForeignKey

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -106,3 +106,4 @@
 | Őry Máté <ory.mate@cloud.bme.hu>
 | Nafees Anwar <h.nafees.anwar@gmail.com>
 | meanmail <github@meanmail.dev>
+| Nicholas Prat <nprat96@gmail.com>

--- a/model_utils/tracker.py
+++ b/model_utils/tracker.py
@@ -263,7 +263,7 @@ class FieldInstanceTracker:
             if deferred_fields:
                 fields = [
                     field for field in self.fields
-                    if field not in deferred_fields
+                    if self.field_map[field] not in deferred_fields
                 ]
             else:
                 fields = self.fields

--- a/tests/models.py
+++ b/tests/models.py
@@ -282,7 +282,7 @@ class TrackedMultiple(models.Model):
 
 class LoopDetectionFieldInstanceTracker(FieldInstanceTracker):
 
-    def set_saved_fields(self, fields=None):
+    def set_saved_fields(self, fields=None) -> None:
         counter = getattr(self.__class__, '__loop_counter', 0)
         if counter > 50:
             raise AssertionError("Infinite Loop Detected!")

--- a/tests/models.py
+++ b/tests/models.py
@@ -24,7 +24,7 @@ from model_utils.models import (
     TimeStampedModel,
     UUIDModel,
 )
-from model_utils.tracker import FieldTracker, ModelTracker, FieldInstanceTracker
+from model_utils.tracker import FieldInstanceTracker, FieldTracker, ModelTracker
 from tests.fields import MutableField
 
 ModelT = TypeVar('ModelT', bound=models.Model, covariant=True)

--- a/tests/models.py
+++ b/tests/models.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, ClassVar, TypeVar, overload
+from typing import Any, ClassVar, Iterable, TypeVar, overload
 
 from django.db import models
 from django.db.models import Manager
@@ -282,7 +282,7 @@ class TrackedMultiple(models.Model):
 
 class LoopDetectionFieldInstanceTracker(FieldInstanceTracker):
 
-    def set_saved_fields(self, fields=None) -> None:
+    def set_saved_fields(self, fields: Iterable[str] | None = None) -> None:
         counter = getattr(self.__class__, '__loop_counter', 0)
         if counter > 50:
             raise AssertionError("Infinite Loop Detected!")

--- a/tests/test_fields/test_field_tracker.py
+++ b/tests/test_fields/test_field_tracker.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
-import pytest
 
+import pytest
 from django.core.cache import cache
 from django.core.exceptions import FieldError
 from django.db import models
-from django.db.models.fields.files import FieldFile
 from django.db.models.deletion import ProtectedError
+from django.db.models.fields.files import FieldFile
 from django.test import TestCase
 
 from model_utils import FieldTracker
@@ -27,8 +27,8 @@ from tests.models import (
     TrackedMultiple,
     TrackedNonFieldAttr,
     TrackedNotDefault,
-    TrackerTimeStamped,
     TrackedProtectedSelfRefFK,
+    TrackerTimeStamped,
 )
 
 if TYPE_CHECKING:

--- a/tests/test_fields/test_field_tracker.py
+++ b/tests/test_fields/test_field_tracker.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 import pytest
-from unittest import skip
 
 from django.core.cache import cache
 from django.core.exceptions import FieldError

--- a/tests/test_fields/test_field_tracker.py
+++ b/tests/test_fields/test_field_tracker.py
@@ -579,7 +579,7 @@ class FieldTrackerProtectedForeignKeyTests(FieldTrackerMixin, TestCase):
     fk_class = Tracked
     tracked_class = TrackedProtectedSelfRefFK
 
-    def setUp(self):
+    def setUp(self) -> None:
         self.old_fk = self.fk_class.objects.create(number=8)
         self.instance = self.tracked_class.objects.create(fk=self.old_fk)
         self.instance_2 = self.tracked_class.objects.create(
@@ -588,7 +588,7 @@ class FieldTrackerProtectedForeignKeyTests(FieldTrackerMixin, TestCase):
         self.instance.self_ref = self.instance_2
         self.instance.save()
 
-    def test_fk_delete(self):
+    def test_fk_delete(self) -> None:
         with pytest.raises(ProtectedError):
             self.old_fk.delete()
 


### PR DESCRIPTION
When deleting a model, that has a reverse relationship to a tracked model with SET_NULL on_delete

## Problem

This issue arrises on these conditions:
1. You delete a model that is target of a foreign key, with `on_delete=SET_NULL` (I believe also with PROTECT)
2. The related model that is going to be deleted has a field tracker that tracks a foreign key field
When this happens, django loads the instance from the db with all fields deferred other than id.  In this code,
```
def current(self, fields=None):
    if fields is None:
        deferred_fields = self.deferred_fields
        if deferred_fields:
            fields = [
                field for field in self.fields
                if field not in deferred_fields
            ]
        else:
            fields = self.fields
    
    return {f: self.get_field_value(f) for f in fields}
```
we skip those deferred fields, but this is where the issue arrises, we don't check `self.field_map[field]` here, so even though the FK is deferred, we still attemp to load it, as we check for, as an example, `foo`, while the deffered field is `foo_id`.

Issue talked about here as well: https://github.com/jazzband/django-model-utils/issues/533
