### PR TITLE
chore: Replicate Django's signature at SoftDelete queryset

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,7 @@ To be released
 - Make `soft` argument to `SoftDeletableModel.delete()` keyword-only
 - `JoinManager` and `JoinManagerMixin` have been deprecated;
   please use ``JoinQueryset.as_manager()`` instead
+- Change `SoftDeletableQuerySetMixin.delete` to replicate Django's API.
 
 4.5.1 (2024-05-02)
 ------------------

--- a/model_utils/managers.py
+++ b/model_utils/managers.py
@@ -363,17 +363,17 @@ class SoftDeletableQuerySetMixin(Generic[ModelT]):
     its ``is_removed`` field to True.
     """
 
-    def delete(self) -> None:
+    def delete(self) -> tuple[int, dict[str, int]]:
         """
         Soft delete objects from queryset (set their ``is_removed``
         field to True)
         """
-        cast(QuerySet[ModelT], self).update(is_removed=True)
+        model: type[ModelT] = self.model  # type: ignore[attr-defined]
+        number_of_deleted_objects = cast(QuerySet[ModelT], self).update(is_removed=True)
+        return number_of_deleted_objects, {model._meta.label: number_of_deleted_objects}
 
 
-# Note that our delete() method does not return anything, unlike Django's.
-# https://github.com/jazzband/django-model-utils/issues/541
-class SoftDeletableQuerySet(SoftDeletableQuerySetMixin[ModelT], QuerySet[ModelT]):  # type: ignore[misc]
+class SoftDeletableQuerySet(SoftDeletableQuerySetMixin[ModelT], QuerySet[ModelT]):
     pass
 
 

--- a/tests/test_models/test_softdeletable_model.py
+++ b/tests/test_models/test_softdeletable_model.py
@@ -53,3 +53,13 @@ class SoftDeletableModelTests(TestCase):
 
     def test_deprecation_warning(self) -> None:
         self.assertWarns(DeprecationWarning, SoftDeletable.objects.all)
+
+    def test_delete_queryset_return(self) -> None:
+        SoftDeletable.available_objects.create(name='a')
+        SoftDeletable.available_objects.create(name='b')
+
+        result = SoftDeletable.available_objects.filter(name="a").delete()
+
+        assert result == (
+            1, {SoftDeletable._meta.label: 1}
+        )


### PR DESCRIPTION
## Problem

Mimics Django's API for `SoftDeletableQuerySetMixin`.

## Solution

Django's API behaves as the [following](https://docs.djangoproject.com/en/5.0/topics/db/queries/#deleting-objects):
![image](https://github.com/jazzband/django-model-utils/assets/24530683/cd05b318-6fac-443d-9996-5f35f50a4e45)

Returning a tuple of type (int, dict[str, int]) where the first element is the number of objects deleted and the second the same count but for the model itself and its relations.

The proposed solution returns the number of objects affected by the update and a made up dict where the key is model's label (no relations as we don't touch it) with aforementioned count.

## Commandments

- [x] Write PEP8 compliant code.
- [x] Cover it with tests.
- [x] Update `CHANGES.rst` file to describe the changes, and quote according issue with `GH-541`.
- [x] Pay attention to backward compatibility, or if it breaks it, explain why.
- [x] Update documentation (if relevant).
