### PR TITLE
Remove catching of `AttributeError` in `DescriptorWrapper`

### DIFF
--- a/model_utils/tracker.py
+++ b/model_utils/tracker.py
@@ -50,10 +50,7 @@ class DescriptorWrapper:
         if instance is None:
             return self
         was_deferred = self.field_name in instance.get_deferred_fields()
-        try:
-            value = self.descriptor.__get__(instance, owner)
-        except AttributeError:
-            value = self.descriptor
+        value = self.descriptor.__get__(instance, owner)
         if was_deferred:
             tracker_instance = getattr(instance, self.tracker_attname)
             tracker_instance.saved_data[self.field_name] = lightweight_deepcopy(value)

--- a/tests/models.py
+++ b/tests/models.py
@@ -249,7 +249,7 @@ class TrackedAbstract(AbstractTracked):
     number = models.IntegerField()
     mutable = MutableField(default=None)
 
-    tracker = FieldTracker()
+    tracker = ModelTracker()
 
 
 class TrackedNotDefault(models.Model):

--- a/tests/test_fields/test_field_tracker.py
+++ b/tests/test_fields/test_field_tracker.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from unittest import skip
-
 from django.core.cache import cache
 from django.core.exceptions import FieldError
 from django.db import models
@@ -877,7 +875,6 @@ class InheritedModelTrackerTests(ModelTrackerTests):
         self.assertTrue(self.tracker.has_changed('name2'))
 
 
-@skip("has known failures")
 class AbstractModelTrackerTests(ModelTrackerTests):
 
     tracked_class = TrackedAbstract


### PR DESCRIPTION
## Problem

I was cleaning up the type annotations in `DescriptorWrapper.__get__()`:
```py
    def __get__(self, instance: models.Model | None, owner: type[models.Model]) -> DescriptorWrapper[T] | T:
        if instance is None:
            return self
        was_deferred = self.field_name in instance.get_deferred_fields()
        try:
            value = self.descriptor.__get__(instance, owner)
        except AttributeError:
            value = self.descriptor
        if was_deferred:
            tracker_instance = getattr(instance, self.tracker_attname)
            tracker_instance.saved_data[self.field_name] = lightweight_deepcopy(value)
        return value
```

After being puzzled by the code for some time, I realized that the `value = self.descriptor` statement was inherently incompatible with the return type of the method. Also storing the descriptor rather than a value in `tracker_instance.saved_data` seems unlikely to be correct.

## Solution

I tried to find out when this exception handler runs, but it turned out it is never executed during unit testing.

Digging deeper, I found that `AbstractModelTrackerTests` was supposed to cover this code, but that test suite was marked as `skip` because it had known test failures. Re-enabling it indeed led to 4 failing test cases, all from `ModelTrackerTests`. The reason for that was simple though: the test model `TrackedAbstract` used a `FieldTracker` rather than a `ModelTracker`. After fixing that, the test suite passed.

There used to be a [bug in Django](https://code.djangoproject.com/ticket/30427) that caused these tests to fail, according to the discussion of #370. That bug was fixed in Django 4.0.

This exception handler was introduced in #367, but subsequent discussion in #370, #381 and #382 suggests that it wasn't the proper solution. As we now have a working test and that test doesn't cause `AttributeError` to be raised, I think it is safe to remove the `try`/`except`.

## Commandments

- [x] Write PEP8 compliant code.
- [x] Cover it with tests.
- [ ] Update `CHANGES.rst` file to describe the changes, and quote according issue with `GH-<issue_number>`.
- [x] Pay attention to backward compatibility, or if it breaks it, explain why.
- [ ] Update documentation (if relevant).

This change should be invisible to end users, as it removes dead code. So I think the ChangeLog and docs steps can be skipped, but if you disagree, let me know and I'll update the PR.
