### PR TITLE
Add formal support for django 5.1

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,7 +3,7 @@ Changelog
 
 To be released
 --------------
-
+- Add formal support for `Django 5.1`
 - Remove MonitorField deprecation warning. `None` - instead of
   `django.utils.timezone.now` will be used when nullable and no default provided (GH-#599)
 - Add deprecation warning for MonitorField. The default value will be `None`

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,7 @@ setup(
         'Framework :: Django :: 4.1',
         'Framework :: Django :: 4.2',
         'Framework :: Django :: 5.0',
+        'Framework :: Django :: 5.1',
     ],
     zip_safe=False,
     package_data={

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ envlist =
     py{38,39,310,311}-dj{41}
     py{38,39,310,311}-dj{42}
     py{310,311,312}-dj{50}
+    py{310,311,312}-dj{51}
     py{310,311,312}-dj{main}
     flake8
     isort
@@ -28,6 +29,7 @@ deps =
     dj41: Django==4.1.*
     dj42: Django==4.2.*
     dj50: Django==5.0.*
+    dj51: Django==5.1.*
     djmain: https://github.com/django/django/archive/main.tar.gz
 ignore_outcome =
     djmain: True


### PR DESCRIPTION
The project has already been tested against the Django main branch, so no additional changes are needed to support Django 5.1.