### PR TITLE
Updated docstring to correctly reflect where 'now' is coming from.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 To be released
 ------------------
 - Add support for `Python 3.12` (GH-#628)
+- Change docstring to reflect the correct place `now` is coming from
 
 5.0.0 (2024-09-01)
 ------------------

--- a/model_utils/fields.py
+++ b/model_utils/fields.py
@@ -26,7 +26,7 @@ class AutoCreatedField(DateTimeFieldBase):
     A DateTimeField that automatically populates itself at
     object creation.
 
-    By default, sets editable=False, default=datetime.now.
+    By default, sets editable=False, default=django.utils.timezone.now.
 
     """
 
@@ -40,7 +40,7 @@ class AutoLastModifiedField(AutoCreatedField):
     """
     A DateTimeField that updates itself on each save() of the model.
 
-    By default, sets editable=False and default=datetime.now.
+    By default, sets editable=False and default=django.utils.timezone.now.
 
     """
     def get_default(self) -> datetime:


### PR DESCRIPTION
Updated docstring to correctly reflect where `now` is coming from in the `AutoCreatedField` and `AutoLastModifiedField` field models.

## Problem

Docstring was showing that the `now` function was coming from `datetime` instead of `django.utils.timezone` 

## Solution

Replaced `datetime.now` to `django.utils.timezone.now` in the docstrings

## Commandments

- [x] Write PEP8 compliant code.
- [x] Cover it with tests (Doesn't break any tests)
- [x] Update `CHANGES.rst` file to describe the changes, and quote according issue with `GH-<issue_number>`.
- [x] Pay attention to backward compatibility, or if it breaks it, explain why.
- [x] Update documentation (if relevant).
