### PR TITLE
Add FieldTracker.diff

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -52,6 +52,7 @@
 | João Amaro <joaoamaro70@gmail.com>
 | Karl WnW <karl.wnw@gmail.com>
 | Keryn Knight <keryn@kerynknight.com>
+| Lucas Rangel Cezimbra <lucas@cezimbra.tec.br>
 | Lucas Wiman <lucaswiman@counsyl.com>
 | Martey Dodoo <martey@mobolic.com>
 | Matthew Schinckel <matt@schinckel.net>

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,7 @@ Changelog
 
 To be released
 ------------------
+- Add `FieldTracker.diff` by @lucasrcezimbra
 - Add support for `Python 3.13` (GH-#628)
 
 5.0.0 (2024-09-01)

--- a/docs/utilities.rst
+++ b/docs/utilities.rst
@@ -216,6 +216,22 @@ and the values of the fields during the last save:
 The ``changed`` method relies on ``has_changed`` to determine which fields
 have changed.
 
+diff
+~~~~~~~
+Returns a dictionary of all fields that have been changed since the last save
+with the previous and current values:
+
+.. code-block:: pycon
+
+    >>> a = Post.objects.create(title='First Post')
+    >>> a.title = 'Welcome'
+    >>> a.body = 'First post!'
+    >>> a.tracker.diff()
+    {'title': ('First Post', 'Welcome'), 'body': ('', 'First post!')}
+
+The ``diff`` method relies on ``has_changed`` to determine which fields
+have changed.
+
 
 Tracking specific fields
 ------------------------

--- a/model_utils/tracker.py
+++ b/model_utils/tracker.py
@@ -310,6 +310,14 @@ class FieldInstanceTracker:
             if self.has_changed(field)
         }
 
+    def diff(self):
+        """Returns dict with the diff of the fields that changed since save"""
+        return {
+            field: (self.previous(field), self.get_field_value(field))
+            for field in self.fields
+            if self.has_changed(field)
+        }
+
 
 class FieldTracker:
 


### PR DESCRIPTION
## Problem
The `FieldTracker.changed` returns only the previous version. There is no method that returns previous and current versions at the same time. 

## Solution
Adds a new method `diff` to the `FieldTracker` to return the previous and the current versions of the changed fields.

## Commandments

- [X] Write PEP8 compliant code.
- [X] Cover it with tests.
- [X] Update `CHANGES.rst` file to describe the changes, and quote according issue with `GH-<issue_number>`.
- [X] Pay attention to backward compatibility, or if it breaks it, explain why.
- [X] Update documentation (if relevant).
