### PR TITLE
Add support for `prefetch_related` to `InheritanceManager`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Changelog
 To be released
 ------------------
 - Add support for `Python 3.13` (GH-#628)
+- Add support for `prefetch_related` to `InheritanceManager`
 
 5.0.0 (2024-09-01)
 ------------------

--- a/docs/managers.rst
+++ b/docs/managers.rst
@@ -84,6 +84,14 @@ If you don't explicitly call ``select_subclasses()`` or ``get_subclass()``,
 an ``InheritanceManager`` behaves identically to a normal ``Manager``; so
 it's safe to use as your default manager for the model.
 
+``InheritanceManager`` supports `prefetch_related`, even in subclasses:
+
+.. code-block:: python
+
+    places = Place.objects.select_subclasses().prefetch_related('bar__manager')
+    # every Bar instance in places will have it's manager relation prefetched
+
+
 .. _contributed by Jeff Elmore: https://jeffelmore.org/2010/11/11/automatic-downcasting-of-inherited-models-in-django/
 
 JoinQueryset

--- a/model_utils/managers.py
+++ b/model_utils/managers.py
@@ -231,18 +231,10 @@ class InheritanceQuerySetMixin(Generic[ModelT]):
             raise ValueError(
                 f"{model!r} is not a subclass of {self.model!r}")
 
-        ancestry: list[str] = []
-        # should be a OneToOneField or None
-        parent_link = model._meta.get_ancestor_link(self.model)
-
-        while parent_link is not None:
-            related = parent_link.remote_field
-            ancestry.insert(0, related.get_accessor_name())
-
-            parent_model = related.model
-            parent_link = parent_model._meta.get_ancestor_link(self.model)
-
-        return LOOKUP_SEP.join(ancestry)
+        return LOOKUP_SEP.join(
+            p.join_field.get_accessor_name()
+            for p in model._meta.get_path_from_parent(self.model)
+        )
 
     def _get_sub_obj_recurse(self, obj: models.Model, s: str) -> ModelT | None:
         rel, _, s = s.partition(LOOKUP_SEP)

--- a/tests/models.py
+++ b/tests/models.py
@@ -44,6 +44,8 @@ class InheritanceManagerTestParent(models.Model):
     related_self = models.OneToOneField(
         "self", related_name="imtests_self", null=True,
         on_delete=models.CASCADE)
+    normal_relation_parent = models.ForeignKey('InheritanceManagerNonChild', null=True, on_delete=models.CASCADE)
+    normal_many_relation_parent = models.ManyToManyField('InheritanceManagerNonChild')
     objects: ClassVar[InheritanceManager[InheritanceManagerTestParent]] = InheritanceManager()
 
     def __str__(self) -> str:

--- a/tests/models.py
+++ b/tests/models.py
@@ -56,6 +56,8 @@ class InheritanceManagerTestParent(models.Model):
 class InheritanceManagerTestChild1(InheritanceManagerTestParent):
     non_related_field_using_descriptor_2 = models.FileField(upload_to="test")
     normal_field_2 = models.TextField()
+    normal_relation = models.ForeignKey('InheritanceManagerNonChild', null=True, on_delete=models.CASCADE)
+    normal_many_relation = models.ManyToManyField('InheritanceManagerNonChild')
     objects: ClassVar[InheritanceManager[InheritanceManagerTestParent]] = InheritanceManager()
 
 
@@ -93,6 +95,10 @@ class InheritanceManagerTestChild4(InheritanceManagerTestParent):
     parent_ptr = models.OneToOneField(
         InheritanceManagerTestParent, related_name='child4_onetoone',
         parent_link=True, on_delete=models.CASCADE)
+
+
+class InheritanceManagerNonChild(models.Model):
+    name = models.CharField(max_length=255)
 
 
 class TimeStamp(TimeStampedModel):


### PR DESCRIPTION
## Problem

Currently, `InheritanceManager` does not support `prefetch_related` very well. This is mainly because Django's `prefetch_related_objects` expects the list it is given to be homogeneous, but for `InheritanceIterable` it is not.
This makes it so a `prefetch_related('child__relation')` will not work correctly in various ways, because
- `prefetch_related` only looks at the first object in the list to make its decisions
- Even if that happens to be correct, the prefetch was written from the point of view of the parent model, but now we have a child model instance.

Additionally, a prefetch `child__relation` will not be accessible in a grandchild, because from Django's point of view that would be `child__grandchild__relation`.

## Solution

The solution has two parts:
1. `InheritanceQuerySetMixin` now overrides `_prefetch_related_objects` and instead of using `self._result_cache` (which has the subclasses generated by `InheritanceIterable`) it first reconstructs the list of base objects. It then uses the base objects for `prefetch_related_objects`. This makes `prefetch_related('child__relation')` work.
2. Copy the prefetch cache (which really has two parts, one for foreign keys and one for many to many) from parents into their children. This ensures that the field descriptors on the child instances can find the cache. Django does make some attempt to do this already, but only for foreign keys and only for one level of ancestry (a child will only look in its direct parent).

In the process I have also fixed the use of raw SQL in `instance_of` and simplified `_get_ancestors_path` by using the API Django already provides. If needed I can split these changes off into their own PR.

## Commandments

- [X] Write PEP8 compliant code.
- [X] Cover it with tests.
- [X] Update `CHANGES.rst` file to describe the changes, and quote according issue with `GH-<issue_number>`.
- [X] Pay attention to backward compatibility, or if it breaks it, explain why.
- [X] Update documentation (if relevant).
