### PR TITLE
Drop support for python 3.8

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,6 @@ jobs:
       max-parallel: 5
       matrix:
         python-version: [
-          '3.8',
           '3.9',
           '3.10',
           '3.11',

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ To be released
 - Add support for `Python 3.13` (GH-#628)
 - Add formal support for `Django 5.2` (GH-#641)
 - Drop support for older versions than `Django 4.2`
+- Drop support for `Python 3.8`
 
 5.0.0 (2024-09-01)
 ------------------

--- a/requirements-mypy.txt
+++ b/requirements-mypy.txt
@@ -1,3 +1,4 @@
-mypy==1.10.0
-django-stubs==5.0.2
+mypy>=1.13.0
+django-stubs==5.1.3
 pytest
+time-machine

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     maintainer='JazzBand',
     url='https://github.com/jazzband/django-model-utils',
     packages=find_packages(exclude=['tests*']),
-    python_requires=">=3.8",
+    python_requires=">=3.9",
     install_requires=['Django>=3.2'],
     classifiers=[
         'Development Status :: 5 - Production/Stable',
@@ -39,7 +39,6 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',

--- a/tox.ini
+++ b/tox.ini
@@ -11,10 +11,8 @@ envlist =
 
 [gh-actions]
 python =
-    3.7: py37
-    3.8: py38, flake8, isort, mypy
     3.9: py39
-    3.10: py310
+    3.10: py310, flake8, isort, mypy
     3.11: py311
     3.12: py312
     3.13: py313
@@ -43,7 +41,7 @@ commands =
 
 [testenv:flake8]
 basepython =
-    python3.8
+    python3.10
 deps =
     flake8
 skip_install = True
@@ -58,16 +56,15 @@ ignore =
     E501
 
 [testenv:isort]
-basepython = python3.8
+basepython = python3.10
 deps = isort
 commands =
     isort model_utils tests setup.py --check-only --diff
 skip_install = True
 
 [testenv:mypy]
-basepython = python3.8
+basepython = python3.10
 deps =
-    time-machine==2.8.2
     -r requirements-mypy.txt
 set_env =
     SQLITE=1


### PR DESCRIPTION
Python 3.8 is EOL so we no longer need to support it. 