### PR TITLE
Allows nullable MonitorField to be populated on creation

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -29,6 +29,7 @@
 | Eran Rundstein <eranrund@gmail.com>
 | Eugene Kuznetsov <atorich@gmail.com>
 | Felipe Prenholato <felipe.rafael@pdg.com.br>
+| Francisco de Maussion <github.com/FranciscodeMaussion>
 | Filipe Ximenes <filipeximenes@gmail.com>
 | Florian Alu <fla@grapps.fr>
 | Germano Massullo <github.com/Germano0>

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,7 @@ To be released
 - Drop support for older versions than `Django 4.2`
 - Drop support for `Python 3.8` and `Python 3.9`
 - Fix `InheritanceQuerySet.iterator()` to stop fetching the entire table (GH-#655)
+- Fixes MonitorField not updating on creation with `when` and `null=True` (GH-#401, GH-#352)
 
 5.0.0 (2024-09-01)
 ------------------

--- a/model_utils/fields.py
+++ b/model_utils/fields.py
@@ -148,10 +148,14 @@ class MonitorField(DateTimeFieldBase):
         value = now()
         previous = getattr(model_instance, self.monitor_attname, None)
         current = self.get_monitored_value(model_instance)
-        if previous != current:
-            if self.when is None or current in self.when:
-                setattr(model_instance, self.attname, value)
-                self._save_initial(model_instance.__class__, model_instance)
+
+        should_update = previous != current
+        if self.when is not None:
+            should_update = (should_update or add) and current in self.when
+
+        if should_update:
+            setattr(model_instance, self.attname, value)
+            self._save_initial(model_instance.__class__, model_instance)
         return super().pre_save(model_instance, add)
 
     def deconstruct(self) -> tuple[str, str, Sequence[Any], dict[str, Any]]:

--- a/tests/models.py
+++ b/tests/models.py
@@ -123,6 +123,11 @@ class MonitorWhenEmpty(models.Model):
     name_changed = MonitorField(monitor="name", when=[])
 
 
+class MonitorWhenNullable(models.Model):
+    name = models.CharField(max_length=25)
+    name_changed = MonitorField(monitor="name", when=["Jose", "Maria"], null=True)
+
+
 class DoubleMonitored(models.Model):
     name = models.CharField(max_length=25)
     name_changed = MonitorField(monitor="name")

--- a/tests/test_fields/test_monitor_field.py
+++ b/tests/test_fields/test_monitor_field.py
@@ -1,12 +1,18 @@
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 import time_machine
 from django.test import TestCase
 
 from model_utils.fields import MonitorField
-from tests.models import DoubleMonitored, Monitored, MonitorWhen, MonitorWhenEmpty
+from tests.models import (
+    DoubleMonitored,
+    Monitored,
+    MonitorWhen,
+    MonitorWhenEmpty,
+    MonitorWhenNullable,
+)
 
 
 class MonitorFieldTests(TestCase):
@@ -83,6 +89,63 @@ class MonitorWhenFieldTests(TestCase):
         changed = self.instance.name_changed
         self.instance.save()
         self.assertEqual(self.instance.name_changed, changed)
+
+
+class MonitorWhenNullableFieldTests(TestCase):
+    """
+    Will record changes only when name is 'Jose'
+    """
+    def setUp(self) -> None:
+        self.arbitrary_datetime = datetime(2016, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+
+    def test_created_with_matching_value(self) -> None:
+        with time_machine.travel(self.arbitrary_datetime):
+            instance = MonitorWhenNullable(name='Jose')
+            instance.save()
+        self.assertEqual(instance.name_changed, self.arbitrary_datetime)
+
+    def test_created_without_matching_value(self) -> None:
+        with time_machine.travel(self.arbitrary_datetime):
+            instance = MonitorWhenNullable(name='Charlie')
+            instance.save()
+        self.assertIsNone(instance.name_changed)
+
+    def test_updated_from_matching_value(self) -> None:
+        with time_machine.travel(self.arbitrary_datetime):
+            instance = MonitorWhenNullable(name='Jose')
+            instance.save()
+        with time_machine.travel(self.arbitrary_datetime + timedelta(hours=2)):
+            instance.name = 'Charlie'
+            instance.save()
+        self.assertEqual(instance.name_changed, self.arbitrary_datetime)
+
+    def test_updated_from_non_matching_value(self) -> None:
+        with time_machine.travel(self.arbitrary_datetime):
+            instance = MonitorWhenNullable(name='Charlie')
+            instance.save()
+        expected_datetime = self.arbitrary_datetime + timedelta(hours=2)
+        with time_machine.travel(expected_datetime):
+            instance.name = 'Jose'
+            instance.save()
+        self.assertEqual(instance.name_changed, expected_datetime)
+
+    def test_update_from_and_to_matching_value(self) -> None:
+        with time_machine.travel(self.arbitrary_datetime):
+            instance = MonitorWhenNullable(name='Jose')
+            instance.save()
+        self.assertEqual(instance.name_changed, self.arbitrary_datetime)
+        expected_datetime = self.arbitrary_datetime + timedelta(hours=2)
+        with time_machine.travel(expected_datetime):
+            instance.name = 'Maria'
+            instance.save()
+        self.assertEqual(instance.name_changed, expected_datetime)
+
+    def test_double_save(self) -> None:
+        instance = MonitorWhenNullable(name='Jose')
+        instance.save()
+        changed = instance.name_changed
+        instance.save()
+        self.assertEqual(instance.name_changed, changed)
 
 
 class MonitorWhenEmptyFieldTests(TestCase):


### PR DESCRIPTION
## Problem

Monitor field does not gets populated on creation since the `previous != current` evaluates to False. The problem is when `when` is setted and not respected on creation.
Related issues:
- https://github.com/jazzband/django-model-utils/issues/401
- https://github.com/jazzband/django-model-utils/issues/352

## Solution
Now 2 checks are done:
- `when is None` we use `previous != current` 
- `when is not None`:
 - we use previous != current and check if `current in when`
 - (change here) check if is `add and current in when`

## Commandments

- [x] Write PEP8 compliant code.
- [x] Cover it with tests.
- [x] Update `CHANGES.rst` file to describe the changes, and quote according issue with `GH-<issue_number>`.
- [x] Pay attention to backward compatibility, or if it breaks it, explain why.
- [x] Update documentation (if relevant).
