### PR TITLE
Fixed broken InheritanceQuerySet.iterator() which was fetching the entire table in memory

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,7 @@ To be released
 - Add formal support for `Django 5.2` (GH-#641)
 - Drop support for older versions than `Django 4.2`
 - Drop support for `Python 3.8` and `Python 3.9`
+- Fix `InheritanceQuerySet.iterator()` to stop fetching the entire table (GH-#655)
 
 5.0.0 (2024-09-01)
 ------------------

--- a/model_utils/managers.py
+++ b/model_utils/managers.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import warnings
+from collections.abc import Iterable
 from typing import TYPE_CHECKING, Any, Generic, Sequence, TypeVar, cast, overload
 
 from django.core.exceptions import ObjectDoesNotExist
@@ -18,8 +19,9 @@ if TYPE_CHECKING:
     from django.db.models.query import BaseIterable
 
 
-def _iter_inheritance_queryset(queryset: QuerySet[ModelT]) -> Iterator[ModelT]:
-    iter: ModelIterable[ModelT] = ModelIterable(queryset)
+def _iter_inheritance_queryset(
+    iter: Iterable[ModelT], queryset: QuerySet[ModelT]
+) -> Iterator[ModelT]:
     if hasattr(queryset, 'subclasses'):
         assert hasattr(queryset, '_get_sub_obj_recurse')
         extras = tuple(queryset.query.extra.keys())
@@ -60,7 +62,7 @@ if TYPE_CHECKING:
 else:
     class InheritanceIterable(ModelIterable):
         def __iter__(self):
-            return _iter_inheritance_queryset(self.queryset)
+            return _iter_inheritance_queryset(super().__iter__(), self.queryset)
 
 
 class InheritanceQuerySetMixin(Generic[ModelT]):

--- a/tests/test_managers/test_inheritance_manager.py
+++ b/tests/test_managers/test_inheritance_manager.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
+from unittest import mock
 
-from django.db import models
+from django.db import connection, models
 from django.test import TestCase
 
 from model_utils.managers import InheritanceManager
@@ -222,6 +223,41 @@ class InheritanceManagerTests(TestCase):
         ))
 
         assert objs_1 == objs_2 == objs_3
+
+    def test_plain_iterator_is_chunked(self) -> None:
+        """
+        Ensure that the iterator method of the queryset uses chunked cursor.
+        """
+        manager = self.get_manager()
+
+        with mock.patch.object(
+            connection, "cursor", side_effect=connection.cursor
+        ) as cursor:
+            with mock.patch.object(
+                connection, "chunked_cursor", side_effect=connection.chunked_cursor
+            ) as chunked_cursor:
+                tuple(manager.iterator(chunk_size=1))
+
+        cursor.assert_not_called()
+        chunked_cursor.assert_called()
+
+    def test_with_subclasses_iterator_is_chunked(self) -> None:
+        """
+        Ensure that the iterator method of the queryset uses chunked cursor
+        even with select_subclasses().
+        """
+        manager = self.get_manager()
+
+        with mock.patch.object(
+            connection, "cursor", side_effect=connection.cursor
+        ) as cursor:
+            with mock.patch.object(
+                connection, "chunked_cursor", side_effect=connection.chunked_cursor
+            ) as chunked_cursor:
+                tuple(manager.select_subclasses().iterator(chunk_size=1))
+
+        cursor.assert_not_called()
+        chunked_cursor.assert_called()
 
 
 class InheritanceManagerUsingModelsTests(TestCase):


### PR DESCRIPTION
## Problem

See https://github.com/jazzband/django-model-utils/issues/654.

Django's `QuerySet.iterator()` passes `chunk_size` and `chunked_fetch` parameters to its `_iterable_class`. If `chunked_fetch` is true, then Django's ModelIterable will select a chunked cursor which is much more memory efficient.

However, while the InheritanceIterable is inheriting from ModelIterable and therefore has access to these parameters, it makes use of a helper function that creates its own ModelIterable instance without passing those parameters. Without these parameters, Django fetches the entire table (`chunked_fetch` is false by default) rendering `.iterator()` completely useless and causing crashes on very large tables.

I'm not entirely sure when this started but it seems to have been an issue for a while now.

## Solution

To fix this, we can modify the helper function to take a plain iterator as parameter which the InheritanceIterable can just pass using `super().__iter__()` (and therefore using the correct implementation of ModelIterable).

This should also allow any future changes to Django's ModelIterable without breaking.

## Commandments

- [x] Write PEP8 compliant code.
- [x] Cover it with tests.
- [x] Update `CHANGES.rst` file to describe the changes, and quote according issue with `GH-<issue_number>`.
- [x] Pay attention to backward compatibility, or if it breaks it, explain why.
- [x] Update documentation (if relevant).
