### PR TITLE
Fix InheritanceQuerySet.annotate() to preserve chained annotations (#312)

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -16,6 +16,7 @@
 | Bojan Mihelac <bmihelac@mihelac.org>
 | Bruno Alla <bruno.alla@founders4schools.org.uk>
 | Bugra Aydin <bugraaydin.cs@gmail.com>
+| Changjun Yeo <lunaradio24@gmail.com>
 | Craig Anderson <craiga@craiga.id.au>
 | Daniel Andrlik <daniel@andrlik.org>
 | Daniel Stanton <stringsonfire@me.com>

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,7 @@ To be released
 - Drop support for older versions than `Django 4.2`
 - Drop support for `Python 3.8` and `Python 3.9`
 - Fix `InheritanceQuerySet.iterator()` to stop fetching the entire table (GH-#655)
+- Fix `InheritanceQuerySet.annotate()` to preserve annotations from previous chained `.annotate()` calls so that all annotated keys are propagated to subclass instances by `InheritanceIterable` (GH-#312)
 
 5.0.0 (2024-09-01)
 ------------------

--- a/model_utils/managers.py
+++ b/model_utils/managers.py
@@ -128,7 +128,11 @@ class InheritanceQuerySetMixin(Generic[ModelT]):
 
     def annotate(self, *args: Any, **kwargs: Any) -> InheritanceQuerySet[ModelT]:
         qset = cast(QuerySet[ModelT], super()).annotate(*args, **kwargs)
-        qset._annotated = [a.default_alias for a in args] + list(kwargs.keys())
+        new_keys = [a.default_alias for a in args] + list(kwargs.keys())
+        existing = list(getattr(qset, '_annotated', []) or [])
+        # See #312. Assign a new list (not in-place extend) to avoid aliasing
+        # via _clone's shallow copy of _annotated.
+        qset._annotated = existing + [k for k in new_keys if k not in existing]
         return qset
 
     def _get_subclasses_recurse(self, model: type[models.Model]) -> list[str]:

--- a/tests/test_managers/test_inheritance_manager.py
+++ b/tests/test_managers/test_inheritance_manager.py
@@ -574,6 +574,36 @@ class InheritanceManagerRelatedTests(InheritanceManagerTests):
             test_count=models.Count('id')).select_subclasses()
         self.assertEqual(qs.get(id=self.child1.id).test_count, 1)
 
+    def test_chained_annotate_with_select_subclasses_preserves_all_annotations(self) -> None:
+        """All annotations from chained .annotate() calls must be propagated
+        to subclass instances when select_subclasses() is used.
+
+        Regression test for #312.
+        """
+        qs = InheritanceManagerTestParent.objects.annotate(
+            first_count=models.Count('id'),
+        ).annotate(
+            second_count=models.Count('id'),
+        ).select_subclasses()
+        obj = qs.get(id=self.child1.id)
+        self.assertEqual(obj.first_count, 1)
+        self.assertEqual(obj.second_count, 1)
+
+    def test_chained_annotate_after_select_subclasses_preserves_all_annotations(self) -> None:
+        """Order should not matter — chained .annotate() after
+        select_subclasses() must also preserve all annotations.
+
+        Regression test for #312.
+        """
+        qs = InheritanceManagerTestParent.objects.select_subclasses().annotate(
+            first_count=models.Count('id'),
+        ).annotate(
+            second_count=models.Count('id'),
+        )
+        obj = qs.get(id=self.child1.id)
+        self.assertEqual(obj.first_count, 1)
+        self.assertEqual(obj.second_count, 1)
+
     def test_clone_when_inheritance_queryset_selects_subclasses_should_clone_them_too(self) -> None:
         qs = InheritanceManagerTestParent.objects.select_subclasses()
         self.assertEqual(qs.subclasses, qs._clone().subclasses)


### PR DESCRIPTION
## Summary

Fixes #312.

`InheritanceQuerySetMixin.annotate()` overwrote `qset._annotated` on every call:

```python
qset._annotated = [a.default_alias for a in args] + list(kwargs.keys())
```

So when multiple `.annotate()` calls were chained together with `select_subclasses()`, only the **last** call's annotation keys were propagated to subclass instances by `InheritanceIterable`. Earlier annotations existed in the SQL (Django keeps them on the parent class result row) but were never copied onto the subclass objects, causing them to silently disappear from the user's perspective.

## Fix

Accumulate annotation keys across chained `.annotate()` calls, deduplicating against keys carried over from the previous queryset:

```python
existing = list(getattr(qset, '_annotated', []) or [])
qset._annotated = existing + [k for k in new_keys if k not in existing]
```

Always assign a **fresh list** rather than `extend`-ing in place, since `_clone` shallow-copies `_annotated` and an in-place mutation would aliase with the parent queryset's list.

## Tests

Two regression tests added in `tests/test_managers/test_inheritance_manager.py` covering both orderings:

- `test_chained_annotate_with_select_subclasses_preserves_all_annotations` — `.annotate().annotate().select_subclasses()`
- `test_chained_annotate_after_select_subclasses_preserves_all_annotations` — `.select_subclasses().annotate().annotate()`

Both tests fail on `master` and pass with this change. All other annotate-related tests continue to pass.

## Test plan

- [x] Added regression tests covering both orderings
- [x] Verified existing annotate tests still pass
- [x] `CHANGES.rst` updated
- [x] `AUTHORS.rst` updated

Note: 4 pre-existing failures in `test_*_iterator_is_chunked` reproduce on `master` as well and are unrelated to this change.