### PR TITLE
Safely handle instance-only field descriptors in FieldTracker.finalize_class (#579)

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -84,6 +84,7 @@
 | Simon Charette <github.com/charettes>
 | Simon Meers <simon@simonmeers.com>
 | Skia <skia@libskia.so>
+| Sparsh Garg <github.com/SparshGarg999>
 | Tavistock <tavistock91@gmail.com>
 | Thomas Schreiber <tom@rizu.fake>
 | Tony Aldridge <zaragopha@hotmail.com>

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,7 @@ To be released
 - Drop support for older versions than `Django 4.2`
 - Drop support for `Python 3.8` and `Python 3.9`
 - Fix `InheritanceQuerySet.iterator()` to stop fetching the entire table (GH-#655)
+- Safely handle instance-only field descriptors in `FieldTracker.finalize_class` (GH-#579)
 
 5.0.0 (2024-09-01)
 ------------------

--- a/model_utils/tracker.py
+++ b/model_utils/tracker.py
@@ -371,10 +371,16 @@ class FieldTracker:
             self.fields = (field.attname for field in sender._meta.fields)
         self.fields = set(self.fields)
         for field_name in self.fields:
-            descriptor: models.Field[Any, Any] = getattr(sender, field_name)
-            wrapper_cls = DescriptorWrapper.cls_for_descriptor(descriptor)
-            wrapped_descriptor = wrapper_cls(field_name, descriptor, self.attname)
-            setattr(sender, field_name, wrapped_descriptor)
+            try:
+                descriptor: models.Field[Any, Any] | None = getattr(sender, field_name, None)
+            except AttributeError:
+                descriptor = None
+            if descriptor is None:
+                descriptor = sender.__dict__.get(field_name)
+            if descriptor is not None:
+                wrapper_cls = DescriptorWrapper.cls_for_descriptor(descriptor)
+                wrapped_descriptor = wrapper_cls(field_name, descriptor, self.attname)
+                setattr(sender, field_name, wrapped_descriptor)
         self.field_map = self.get_field_map(sender)
         self.patch_init(sender)
         self.model_class = sender

--- a/tests/test_fields/test_field_tracker.py
+++ b/tests/test_fields/test_field_tracker.py
@@ -1011,3 +1011,38 @@ class TrackerContextDecoratorTests(TestCase):
             self.assertChanged('name')
 
         self.assertNotChanged('name')
+
+    def test_tracker_with_instance_only_descriptor(self) -> None:
+        class InstanceOnlyDescriptor:
+            def __init__(self, name: str) -> None:
+                self.name = name
+
+            def __get__(self, instance: object, owner: type[object]) -> Any:
+                if instance is None:
+                    raise AttributeError(f"{self.name} must be accessed via instance.")
+                return instance.__dict__.get(self.name, 0)
+
+            def __set__(self, instance: object, value: Any) -> None:
+                instance.__dict__[self.name] = value
+
+        class CustomDescriptorField(models.IntegerField):
+            def contribute_to_class(self, cls: type[models.Model], name: str, **kwargs: Any) -> None:
+                super().contribute_to_class(cls, name, **kwargs)
+                setattr(cls, name, InstanceOnlyDescriptor(name))
+
+        class ModelWithInstanceOnlyDescriptor(models.Model):
+            pos = CustomDescriptorField(default=0)
+            tracker = FieldTracker()
+
+            class Meta:
+                app_label = 'tests'
+
+        instance = ModelWithInstanceOnlyDescriptor(pos=5)
+        self.assertEqual(instance.pos, 5)
+        self.assertEqual(instance.tracker.previous('pos'), None)
+        instance.pk = 1
+        instance.tracker.set_saved_fields()
+        self.assertEqual(instance.tracker.previous('pos'), 5)
+        instance.pos = 10
+        self.assertEqual(instance.tracker.previous('pos'), 5)
+        self.assertTrue(instance.tracker.has_changed('pos'))


### PR DESCRIPTION
## Summary
Fixes #579

When a custom field uses a descriptor that requires being called on an instance (or raises `AttributeError` when `instance is None`, such as `django-positions`'s `PositionField`), `getattr(sender, field_name)` in `FieldTracker.finalize_class` propagated the `AttributeError` during Django model preparation.

## Solution
1. In `FieldTracker.finalize_class`, safely retrieve descriptors using `getattr(sender, field_name, None)` with an `except AttributeError` handler.
2. Fall back to retrieving the descriptor from `sender.__dict__.get(field_name)` so it can be wrapped by `DescriptorWrapper` without calling its `__get__(None, sender)` prematurely.
3. Added a regression test `test_tracker_with_instance_only_descriptor` in `tests/test_fields/test_field_tracker.py`.
4. Updated `CHANGES.rst` and `AUTHORS.rst`.

## Validation
- Ran pytest on `tests/test_fields/test_field_tracker.py`: 136 passed.