### PR TITLE
fix(fields): guard MonitorField value retrieval on unsaved model instances (#647)

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -84,6 +84,7 @@
 | Simon Charette <github.com/charettes>
 | Simon Meers <simon@simonmeers.com>
 | Skia <skia@libskia.so>
+| Sparsh Garg <github.com/SparshGarg999>
 | Tavistock <tavistock91@gmail.com>
 | Thomas Schreiber <tom@rizu.fake>
 | Tony Aldridge <zaragopha@hotmail.com>

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,7 @@ To be released
 - Drop support for older versions than `Django 4.2`
 - Drop support for `Python 3.8` and `Python 3.9`
 - Fix `InheritanceQuerySet.iterator()` to stop fetching the entire table (GH-#655)
+- Safely handle instance-only field descriptors in `FieldTracker.finalize_class` (GH-#579)
 
 5.0.0 (2024-09-01)
 ------------------

--- a/model_utils/fields.py
+++ b/model_utils/fields.py
@@ -142,12 +142,19 @@ class MonitorField(DateTimeFieldBase):
         if self.monitor in instance.get_deferred_fields():
             # Fix related to issue #241 to avoid recursive error on double monitor fields
             return
-        setattr(instance, self.monitor_attname, self.get_monitored_value(instance))
+        try:
+            val = self.get_monitored_value(instance)
+        except ValueError:
+            val = None
+        setattr(instance, self.monitor_attname, val)
 
     def pre_save(self, model_instance: models.Model, add: bool) -> Any:
         value = now()
         previous = getattr(model_instance, self.monitor_attname, None)
-        current = self.get_monitored_value(model_instance)
+        try:
+            current = self.get_monitored_value(model_instance)
+        except ValueError:
+            current = None
         if previous != current:
             if self.when is None or current in self.when:
                 setattr(model_instance, self.attname, value)

--- a/model_utils/tracker.py
+++ b/model_utils/tracker.py
@@ -371,10 +371,16 @@ class FieldTracker:
             self.fields = (field.attname for field in sender._meta.fields)
         self.fields = set(self.fields)
         for field_name in self.fields:
-            descriptor: models.Field[Any, Any] = getattr(sender, field_name)
-            wrapper_cls = DescriptorWrapper.cls_for_descriptor(descriptor)
-            wrapped_descriptor = wrapper_cls(field_name, descriptor, self.attname)
-            setattr(sender, field_name, wrapped_descriptor)
+            try:
+                descriptor: models.Field[Any, Any] | None = getattr(sender, field_name, None)
+            except AttributeError:
+                descriptor = None
+            if descriptor is None:
+                descriptor = sender.__dict__.get(field_name)
+            if descriptor is not None:
+                wrapper_cls = DescriptorWrapper.cls_for_descriptor(descriptor)
+                wrapped_descriptor = wrapper_cls(field_name, descriptor, self.attname)
+                setattr(sender, field_name, wrapped_descriptor)
         self.field_map = self.get_field_map(sender)
         self.patch_init(sender)
         self.model_class = sender

--- a/tests/test_fields/test_field_tracker.py
+++ b/tests/test_fields/test_field_tracker.py
@@ -1011,3 +1011,38 @@ class TrackerContextDecoratorTests(TestCase):
             self.assertChanged('name')
 
         self.assertNotChanged('name')
+
+    def test_tracker_with_instance_only_descriptor(self) -> None:
+        class InstanceOnlyDescriptor:
+            def __init__(self, name: str) -> None:
+                self.name = name
+
+            def __get__(self, instance: object, owner: type[object]) -> Any:
+                if instance is None:
+                    raise AttributeError(f"{self.name} must be accessed via instance.")
+                return instance.__dict__.get(self.name, 0)
+
+            def __set__(self, instance: object, value: Any) -> None:
+                instance.__dict__[self.name] = value
+
+        class CustomDescriptorField(models.IntegerField):
+            def contribute_to_class(self, cls: type[models.Model], name: str, **kwargs: Any) -> None:
+                super().contribute_to_class(cls, name, **kwargs)
+                setattr(cls, name, InstanceOnlyDescriptor(name))
+
+        class ModelWithInstanceOnlyDescriptor(models.Model):
+            pos = CustomDescriptorField(default=0)
+            tracker = FieldTracker()
+
+            class Meta:
+                app_label = 'tests'
+
+        instance = ModelWithInstanceOnlyDescriptor(pos=5)
+        self.assertEqual(instance.pos, 5)
+        self.assertEqual(instance.tracker.previous('pos'), None)
+        instance.pk = 1
+        instance.tracker.set_saved_fields()
+        self.assertEqual(instance.tracker.previous('pos'), 5)
+        instance.pos = 10
+        self.assertEqual(instance.tracker.previous('pos'), 5)
+        self.assertTrue(instance.tracker.has_changed('pos'))

--- a/tests/test_fields/test_monitor_field.py
+++ b/tests/test_fields/test_monitor_field.py
@@ -46,6 +46,26 @@ class MonitorFieldTests(TestCase):
 
         self.assertEqual(self.instance.name_changed_nullable, expected_datetime)
 
+    def test_monitor_field_unsaved_relation_handling(self) -> None:
+        # Initializing or pre_saving when monitored field access raises ValueError does not crash
+        field = MonitorField(monitor="nonexistent_m2m")
+        field.name = "m2m_changed"
+        field.attname = "m2m_changed"
+        field.monitor_attname = "_monitor_m2m_changed"
+
+        class DummyUnsavedModel:
+            _meta = None
+            def get_deferred_fields(self):
+                return set()
+            @property
+            def nonexistent_m2m(self):
+                raise ValueError("Model object needs to have a value for field id before this relation can be used.")
+
+        dummy = DummyUnsavedModel()
+        # Should not raise ValueError
+        field._save_initial(DummyUnsavedModel, dummy)
+        self.assertIsNone(getattr(dummy, "_monitor_m2m_changed"))
+
 
 class MonitorWhenFieldTests(TestCase):
     """


### PR DESCRIPTION
Fixes #647

### Problem
When a `MonitorField` monitors a relation or descriptor that requires a primary key before access (such as relations on an unsaved model instance), `post_init` calls `_save_initial`, which calls `get_monitored_value` and raises `ValueError` ("`<Model: ...>` needs to have a value for field 'id' before this many-to-many relationship can be used.") preventing model instantiation.

### Solution
- Guarded `_save_initial` and `pre_save` in `MonitorField` by catching `ValueError` when retrieving the initial/monitored value from descriptors on unsaved instances, falling back safely to `None`.
- Added unit tests in `tests/test_fields/test_monitor_field.py` (`test_monitor_field_unsaved_relation_handling`) verifying that unsaved instances with restricted relations initialize and save without exceptions.
