### PR TITLE
fix(translations): initialize django in translations.py before running management commands (#609)

### DIFF
--- a/tests/test_miscellaneous.py
+++ b/tests/test_miscellaneous.py
@@ -27,3 +27,12 @@ class GetExcerptTests(TestCase):
     def test_middle_of_line(self) -> None:
         e = get_excerpt("some text <!-- split --> more text")
         self.assertEqual(e, "some text <!-- split --> more text")
+
+
+class TranslationsScriptTests(TestCase):
+    def test_translations_run_compile(self) -> None:
+        from unittest import mock
+        from translations import run
+        with mock.patch("django.core.management.call_command") as mock_call:
+            run("compile")
+            mock_call.assert_called_once_with("compilemessages")

--- a/translations.py
+++ b/translations.py
@@ -22,6 +22,7 @@ DEFAULT_SETTINGS = dict(
 def run(command):
     if not settings.configured:
         settings.configure(**DEFAULT_SETTINGS)
+    django.setup()
 
     parent = os.path.dirname(os.path.abspath(__file__))
     appdir = os.path.join(parent, 'model_utils')


### PR DESCRIPTION
Fixes #609

### Problem
Running `translations.py make` or `translations.py compile` fails with `django.core.exceptions.AppRegistryNotReady: Apps aren't loaded yet.` because Django's application registry is never initialized prior to executing `call_command('makemessages')` / `call_command('compilemessages')`.

### Solution
- Added `django.setup()` right after configuring settings in `translations.py:run()`.
- Added unit tests in `tests/test_miscellaneous.py` to verify `translations.run` works without raising exceptions.
