### PR TITLE
Add CreatedModel abstract base class

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -16,6 +16,7 @@
 | Bojan Mihelac <bmihelac@mihelac.org>
 | Bruno Alla <bruno.alla@founders4schools.org.uk>
 | Bugra Aydin <bugraaydin.cs@gmail.com>
+| Chris <github.com/ChrisJr404>
 | Craig Anderson <craiga@craiga.id.au>
 | Daniel Andrlik <daniel@andrlik.org>
 | Daniel Stanton <stringsonfire@me.com>

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,7 @@ To be released
 - Drop support for older versions than `Django 4.2`
 - Drop support for `Python 3.8` and `Python 3.9`
 - Fix `InheritanceQuerySet.iterator()` to stop fetching the entire table (GH-#655)
+- Add `CreatedModel` abstract base class providing a self-updating `created` field (GH-#525)
 
 5.0.0 (2024-09-01)
 ------------------

--- a/docs/models.rst
+++ b/docs/models.rst
@@ -48,6 +48,15 @@ This abstract base class just provides self-updating ``created`` and
 ``modified`` fields on any model that inherits from it.
 
 
+CreatedModel
+------------
+
+This abstract base class just provides a self-updating ``created`` field on
+any model that inherits from it. Use it when you only care about when a row
+was first created and don't need the ``modified`` field that
+``TimeStampedModel`` adds.
+
+
 StatusModel
 -----------
 

--- a/model_utils/models.py
+++ b/model_utils/models.py
@@ -46,6 +46,18 @@ class TimeStampedModel(models.Model):
         abstract = True
 
 
+class CreatedModel(models.Model):
+    """
+    An abstract base class model that provides a self-updating
+    ``created`` field.
+
+    """
+    created = AutoCreatedField(_('created'))
+
+    class Meta:
+        abstract = True
+
+
 class TimeFramedModel(models.Model):
     """
     An abstract base class model that provides ``start``

--- a/tests/models.py
+++ b/tests/models.py
@@ -18,6 +18,7 @@ from model_utils.managers import (
     SoftDeletableQuerySet,
 )
 from model_utils.models import (
+    CreatedModel,
     SoftDeletableModel,
     StatusModel,
     TimeFramedModel,
@@ -96,6 +97,10 @@ class InheritanceManagerTestChild4(InheritanceManagerTestParent):
 
 
 class TimeStamp(TimeStampedModel):
+    test_field = models.PositiveSmallIntegerField(default=0)
+
+
+class Created(CreatedModel):
     test_field = models.PositiveSmallIntegerField(default=0)
 
 

--- a/tests/test_models/test_created_model.py
+++ b/tests/test_models/test_created_model.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import time_machine
+from django.test import TestCase
+
+from tests.models import Created
+
+
+class CreatedModelTests(TestCase):
+    def test_created(self) -> None:
+        with time_machine.travel(datetime(2016, 1, 1, tzinfo=timezone.utc)):
+            obj = Created.objects.create()
+        self.assertEqual(obj.created, datetime(2016, 1, 1, tzinfo=timezone.utc))
+
+    def test_created_is_not_changed_on_later_save(self) -> None:
+        with time_machine.travel(datetime(2016, 1, 1, tzinfo=timezone.utc)):
+            obj = Created.objects.create()
+
+        with time_machine.travel(datetime(2016, 1, 2, tzinfo=timezone.utc)):
+            obj.test_field = 1
+            obj.save()
+
+        self.assertEqual(obj.created, datetime(2016, 1, 1, tzinfo=timezone.utc))
+
+    def test_overriding_created_via_object_creation(self) -> None:
+        different_date = datetime(2010, 1, 1, tzinfo=timezone.utc)
+        obj = Created.objects.create(created=different_date)
+        self.assertEqual(obj.created, different_date)


### PR DESCRIPTION
Closes #525.

Adds a `CreatedModel` abstract base class, which is like `TimeStampedModel` but
only carries the `created` field. Handy when a model just needs to know when a
row was first created and the self-updating `modified` field would be dead weight.

The implementation reuses the same `AutoCreatedField` that `TimeStampedModel`
already uses, so behaviour matches (created is set on insert and stays put on
later saves). Added tests, a docs section, and a changelog entry.
